### PR TITLE
Change property version should be handled by upgrade dependency version

### DIFF
--- a/src/main/resources/META-INF/rewrite/micronaut2-to-3.yml
+++ b/src/main/resources/META-INF/rewrite/micronaut2-to-3.yml
@@ -36,9 +36,6 @@ recipeList:
       artifactId: micronaut-bom
       newVersion: 3.0.0-M5
       trustParent: true
-  - org.openrewrite.maven.ChangePropertyValue:
-      key: micronaut.version
-      newValue: 3.0.0-M5
   - org.openrewrite.java.micronaut.UpgradeGradlePropertiesVersion:
       newVersion: 3.0.0-M5
   - org.openrewrite.java.ChangePackage:


### PR DESCRIPTION
I believe this was valuable in cases such as lukas-krecan/ShedLock where the `micronaut-bom` version was in a `dependencyManagement` section with it's `version` value resolved from it's parent properties. Instead of manually changing the property value based on the key `micronaut.version` (which may change 🤷‍♀️ ), this should now be handled by https://github.com/openrewrite/rewrite/pull/896 