### PR TITLE
Correct Micronaut maven plugin coordinates.

### DIFF
--- a/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
+++ b/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
@@ -84,6 +84,10 @@ recipeList:
   - org.openrewrite.gradle.plugins.UpgradePluginVersion:
       pluginIdPattern: io.micronaut.test-resources-consumer
       newVersion: 4.0.0-M4
+  - org.openrewrite.maven.ChangePluginGroupIdAndArtifactId:
+      oldGroupId: io.micronaut.build
+      oldArtifactId: micronaut-maven-plugin
+      newGroupId: io.micronaut.maven
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.micronaut.UpdateMicronautPlatformBom

--- a/src/test/java/org/openrewrite/java/micronaut/UpdateBuildPluginsTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpdateBuildPluginsTest.java
@@ -15,56 +15,99 @@
  */
 package org.openrewrite.java.micronaut;
 
-import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.java.Assertions.mavenProject;
+import static org.openrewrite.maven.Assertions.pomXml;
 
 public class UpdateBuildPluginsTest implements RewriteTest {
 
-    @Language("groovy")
-    private final String initialBuild = """
-            plugins {
-                id("com.github.johnrengelman.shadow") version "7.1.2"
-                id("io.micronaut.application") version "3.7.9"
-                id("io.micronaut.minimal.application") version "3.7.9"
-                id("io.micronaut.aot") version "3.7.9"
-                id("io.micronaut.crac") version "3.7.9"
-                id("io.micronaut.docker") version "3.7.9"
-                id("io.micronaut.graalvm") version "3.7.9"
-                id("io.micronaut.library") version "3.7.9"
-                id("io.micronaut.minimal.library") version "3.7.9"
-                id("io.micronaut.test-resources") version "3.5.1"
-                id("io.micronaut.test-resources-consumer") version "3.5.1"
-            }
-        """;
-
-    @Language("groovy")
-    private final String updatedPlugins = """
-            plugins {
-                id("com.github.johnrengelman.shadow") version "8.1.1"
-                id("io.micronaut.application") version "4.0.0-M4"
-                id("io.micronaut.minimal.application") version "4.0.0-M4"
-                id("io.micronaut.aot") version "4.0.0-M4"
-                id("io.micronaut.crac") version "4.0.0-M4"
-                id("io.micronaut.docker") version "4.0.0-M4"
-                id("io.micronaut.graalvm") version "4.0.0-M4"
-                id("io.micronaut.library") version "4.0.0-M4"
-                id("io.micronaut.minimal.library") version "4.0.0-M4"
-                id("io.micronaut.test-resources") version "4.0.0-M4"
-                id("io.micronaut.test-resources-consumer") version "4.0.0-M4"
-            }
-        """;
-
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipeFromResource("/META-INF/rewrite/micronaut3-to-4.yml", "org.openrewrite.java.micronaut.UpdateBuildPlugins");
+        spec.recipeFromResource("/META-INF/rewrite/micronaut3-to-4.yml", "org.openrewrite.java.micronaut.UpdateMicronautPlatformBom",
+          "org.openrewrite.java.micronaut.UpdateBuildPlugins");
     }
 
     @Test
-    void updateBuildPlugins() {
-        rewriteRun(buildGradle(initialBuild, updatedPlugins));
+    void updateGradleBuildPlugins() {
+        rewriteRun(
+          //language=groovy
+          buildGradle("""
+                plugins {
+                    id("com.github.johnrengelman.shadow") version "7.1.2"
+                    id("io.micronaut.application") version "3.7.9"
+                    id("io.micronaut.minimal.application") version "3.7.9"
+                    id("io.micronaut.aot") version "3.7.9"
+                    id("io.micronaut.crac") version "3.7.9"
+                    id("io.micronaut.docker") version "3.7.9"
+                    id("io.micronaut.graalvm") version "3.7.9"
+                    id("io.micronaut.library") version "3.7.9"
+                    id("io.micronaut.minimal.library") version "3.7.9"
+                    id("io.micronaut.test-resources") version "3.5.1"
+                    id("io.micronaut.test-resources-consumer") version "3.5.1"
+                }
+            """, """
+                plugins {
+                    id("com.github.johnrengelman.shadow") version "8.1.1"
+                    id("io.micronaut.application") version "4.0.0-M4"
+                    id("io.micronaut.minimal.application") version "4.0.0-M4"
+                    id("io.micronaut.aot") version "4.0.0-M4"
+                    id("io.micronaut.crac") version "4.0.0-M4"
+                    id("io.micronaut.docker") version "4.0.0-M4"
+                    id("io.micronaut.graalvm") version "4.0.0-M4"
+                    id("io.micronaut.library") version "4.0.0-M4"
+                    id("io.micronaut.minimal.library") version "4.0.0-M4"
+                    id("io.micronaut.test-resources") version "4.0.0-M4"
+                    id("io.micronaut.test-resources-consumer") version "4.0.0-M4"
+                } 
+            """));
+    }
+
+    @Test
+    void updateMavenBuildPlugin() {
+        rewriteRun(mavenProject("project",
+            //language=xml
+            pomXml("""
+                    <project>
+                        <groupId>com.mycompany.app</groupId>
+                        <artifactId>my-app</artifactId>
+                        <version>1</version>
+                        <parent>
+                            <groupId>io.micronaut</groupId>
+                            <artifactId>micronaut-parent</artifactId>
+                            <version>3.9.1</version>
+                        </parent>
+                        <build>
+                          <plugins>
+                              <plugin>
+                                  <groupId>io.micronaut.build</groupId>
+                                  <artifactId>micronaut-maven-plugin</artifactId>
+                              </plugin>
+                          </plugins>
+                        </build>
+                    </project>    
+                """, """
+                    <project>
+                        <groupId>com.mycompany.app</groupId>
+                        <artifactId>my-app</artifactId>
+                        <version>1</version>
+                        <parent>
+                            <groupId>io.micronaut.platform</groupId>
+                            <artifactId>micronaut-parent</artifactId>
+                            <version>4.0.0-M3</version>
+                        </parent>
+                        <build>
+                          <plugins>
+                              <plugin>
+                                  <groupId>io.micronaut.maven</groupId>
+                                  <artifactId>micronaut-maven-plugin</artifactId>
+                              </plugin>
+                          </plugins>
+                        </build>
+                    </project>
+                """)));
     }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
The `org.openrewrite.java.micronaut.UpdateBuildPlugins` recipe invoked by 
`org.openrewrite.java.micronaut.Micronaut3to4Migration` now updates the Micronaut maven plugin groupId to the correct 
new coordinates.

Resolves #53 
