### PR TITLE
Revise approach to upgrading Micronaut Validation.

### DIFF
--- a/src/main/java/org/openrewrite/java/micronaut/AddAnnotationProcessorPath.java
+++ b/src/main/java/org/openrewrite/java/micronaut/AddAnnotationProcessorPath.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.micronaut;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.maven.MavenIsoVisitor;
+import org.openrewrite.maven.MavenVisitor;
+import org.openrewrite.xml.AddToTagVisitor;
+import org.openrewrite.xml.XPathMatcher;
+import org.openrewrite.xml.tree.Xml;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class AddAnnotationProcessorPath extends ScanningRecipe<AddAnnotationProcessorPath.Scanned> {
+
+    @Option(displayName = "GroupId",
+            description = "The groupId to use.",
+            example = "corp.internal.openrewrite.recipe")
+    String groupId;
+
+    @Option(displayName = "ArtifactId",
+            description = "The artifactId to use.",
+            example = "my-new-annotation-processor")
+    String artifactId;
+
+    @Option(displayName = "Version",
+            description = "An exact version string for the annotation processor path.",
+            example = "${micronaut.validation}")
+    String version;
+
+    @Option(displayName = "Only if using",
+            description = "Used to determine if the annotation processor will be added.",
+            example = "jakarta.validation.constraints.*")
+    String onlyIfUsing;
+
+    @Option(displayName = "Exclusions",
+            description = "A list of exclusions to apply to the annotation processor path in the format groupId:artifactId",
+            example = "io.micronaut:micronaut-inject",
+            required = false)
+    @Nullable
+    List<String> exclusions;
+
+    @Override
+    public String getDisplayName() {
+        return "Add Maven annotation processor path";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Add the groupId, artifactId, version, and exclusions of a Maven annotation processor path.";
+    }
+
+    public static class Scanned {
+        boolean usingType;
+    }
+
+    @Override
+    public Scanned getInitialValue(ExecutionContext ctx) {
+        return new Scanned();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Scanned acc) {
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                SourceFile sourceFile = (SourceFile) requireNonNull(tree);
+                if (tree instanceof JavaSourceFile) {
+                    boolean sourceFileUsesType = sourceFile != new UsesType<>(onlyIfUsing, true).visit(sourceFile, ctx);
+                    acc.usingType |= sourceFileUsesType;
+                }
+                return sourceFile;
+            }
+        };
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(Scanned acc) {
+        return Preconditions.check(acc.usingType, new MavenVisitor<ExecutionContext>() {
+            @Override
+            public Xml visitDocument(Xml.Document document, ExecutionContext ctx) {
+                return new CheckAnnotationProcessorPathVisitor().visitNonNull(document, ctx);
+            }
+        });
+    }
+
+    private class CheckAnnotationProcessorPathVisitor extends MavenIsoVisitor<ExecutionContext> {
+
+        private final XPathMatcher ANNOTATION_PROCESSOR_PATH_MATCHER = new XPathMatcher("/project/build/plugins/plugin/configuration/annotationProcessorPaths/path");
+
+        @Override
+        public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
+            if (ANNOTATION_PROCESSOR_PATH_MATCHER.matches(getCursor()) &&
+                    groupId.equals(tag.getChildValue("groupId").orElse(null)) &&
+                    artifactId.equals(tag.getChildValue("artifactId").orElse(null))) {
+                getCursor().putMessageOnFirstEnclosing(Xml.Document.class, "alreadyHasAnnotationProcessor", true);
+                return tag;
+            }
+            return super.visitTag(tag, ctx);
+        }
+
+        @Override
+        public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
+            Xml.Document maven = super.visitDocument(document, ctx);
+
+            if (getCursor().getMessage("alreadyHasAnnotationProcessor", false)) {
+                return document;
+            }
+
+            doAfterVisit(new InsertAnnotationProcessorPath());
+
+            return maven;
+        }
+    }
+
+    private class InsertAnnotationProcessorPath extends MavenIsoVisitor<ExecutionContext> {
+
+        private final XPathMatcher ANNOTATION_PROCESSOR_PATHS_MATCHER = new XPathMatcher("/project/build/plugins/plugin/configuration/annotationProcessorPaths");
+
+        @Override
+        public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
+            if (ANNOTATION_PROCESSOR_PATHS_MATCHER.matches(getCursor())) {
+                Xml.Tag pathTag = Xml.Tag.build(
+                        "\n<path>\n" +
+                                "<groupId>" + groupId + "</groupId>\n" +
+                                "<artifactId>" + artifactId + "</artifactId>\n" +
+                                "<version>" + version + "</version>\n" +
+                                buildExclusionsContent() +
+                                "</path>"
+                );
+
+                doAfterVisit(new AddToTagVisitor<>(tag, pathTag));
+
+                maybeUpdateModel();
+
+                return tag;
+            }
+            return super.visitTag(tag, ctx);
+        }
+
+        private String buildExclusionsContent() {
+            if (exclusions == null) {
+                return "";
+            }
+            return "<exclusions>\n" +
+                    exclusions.stream().map(exclusion -> {
+                        StringBuilder exclusionContent = new StringBuilder("<exclusion>\n");
+                        String[] exclusionParts = exclusion.split(":");
+                        if (exclusionParts.length != 2) {
+                            throw new IllegalStateException("Expected an exclusion in the form of groupId:artifactId but was '" + exclusion + "'");
+                        }
+                        exclusionContent.append("<groupId>").append(exclusionParts[0]).append("</groupId>\n")
+                                .append("<artifactId>").append(exclusionParts[1]).append("</artifactId>\n")
+                                .append("</exclusion>\n");
+                        return exclusionContent.toString();
+                    }).collect(Collectors.joining()) +
+                    "</exclusions>";
+        }
+    }
+}

--- a/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
+++ b/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
@@ -125,33 +125,29 @@ name: org.openrewrite.java.micronaut.UpdateMicronautValidation
 displayName: Update to Micronaut Validation 4.x
 description: This recipe will add jakarta validation dependency if needed, migrate from javax.validation if needed, and update micronaut validation dependencies.
 recipeList:
-  - org.openrewrite.java.migrate.jakarta.JavaxValidationMigrationToJakartaValidation
-  - org.openrewrite.gradle.ChangeDependencyGroupId:
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: javax.validation
+      newPackageName: jakarta.validation
+      recursive: true
+  - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: io.micronaut
       artifactId: micronaut-validation
-      newGroupId: io.micronaut.validation
-      configuration: implementation
-  - org.openrewrite.gradle.ChangeDependencyGroupId:
-      groupId: io.micronaut
-      artifactId: micronaut-http-validation
-      newGroupId: io.micronaut.validation
-      configuration: annotationProcessor
-  - org.openrewrite.gradle.ChangeDependencyArtifactId:
+  - org.openrewrite.java.dependencies.AddDependency:
       groupId: io.micronaut.validation
-      artifactId: micronaut-http-validation
-      newArtifactId: micronaut-validation-processor
+      artifactId: micronaut-validation
+      configuration: implementation
+      scope: compile
+      onlyIfUsing: jakarta.validation.constraints.*
+  - org.openrewrite.gradle.AddDependency:
+      groupId: io.micronaut.validation
+      artifactId: micronaut-validation-processor
       configuration: annotationProcessor
-  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
-      oldGroupId: io.micronaut
-      oldArtifactId: micronaut-validation
-      newGroupId: io.micronaut.validation
-      newVersion: LATEST
-  - org.openrewrite.java.micronaut.ChangeAnnotationProcessorPath:
-      oldGroupId: io.micronaut
-      oldArtifactId: micronaut-http-validation
-      newGroupId: io.micronaut.validation
-      newArtifactId: micronaut-validation-processor
-      newVersion: ${micronaut.validation.version}
+      onlyIfUsing: jakarta.validation.constraints.*
+  - org.openrewrite.java.micronaut.AddAnnotationProcessorPath:
+      groupId: io.micronaut.validation
+      artifactId: micronaut-validation-processor
+      version: ${micronaut.validation.version}
+      onlyIfUsing: jakarta.validation.constraints.*
       exclusions:
         - io.micronaut:micronaut-inject
 ---

--- a/src/test/java/org/openrewrite/java/micronaut/UpdateMicronautValidationTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpdateMicronautValidationTest.java
@@ -24,8 +24,10 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
+import static org.openrewrite.properties.Assertions.properties;
 
 class UpdateMicronautValidationTest implements RewriteTest {
 
@@ -39,6 +41,7 @@ class UpdateMicronautValidationTest implements RewriteTest {
             .build()
             .activateRecipes(
               "org.openrewrite.java.micronaut.UpdateMicronautPlatformBom",
+              "org.openrewrite.java.micronaut.UpdateBuildPlugins",
               "org.openrewrite.java.micronaut.UpdateMicronautValidation"));
     }
 
@@ -68,180 +71,456 @@ class UpdateMicronautValidationTest implements RewriteTest {
       }
       """;
 
-    @Language("groovy")
-    private final String buildGradleInitial = """
-      dependencies {
-          annotationProcessor("io.micronaut:micronaut-http-validation")
-          implementation("io.micronaut:micronaut-http-client")
-          implementation("io.micronaut:micronaut-jackson-databind")
-          implementation("io.micronaut:micronaut-validation")
-          runtimeOnly("ch.qos.logback:logback-classic")
-      }
-      """;
+    //@Language("xml")
+    //private final String pomInitial = ;
 
-    @Language("groovy")
-    private final String buildGradleExpected = """
-          dependencies {
-              annotationProcessor("io.micronaut.validation:micronaut-validation-processor")
-              implementation("io.micronaut:micronaut-http-client")
-              implementation("io.micronaut:micronaut-jackson-databind")
-              implementation("io.micronaut.validation:micronaut-validation")
-              runtimeOnly("ch.qos.logback:logback-classic")
-          }
-      """;
-
-    @Language("xml")
-    private final String pomInitial = """
-      <project>
-          <groupId>com.mycompany.app</groupId>
-          <artifactId>my-app</artifactId>
-          <version>1</version>
-          <parent>
-              <groupId>io.micronaut</groupId>
-              <artifactId>micronaut-parent</artifactId>
-              <version>3.9.1</version>
-          </parent>
-          <dependencies>
-              <dependency>
-                  <groupId>io.micronaut</groupId>
-                  <artifactId>micronaut-http-client</artifactId>
-                  <scope>compile</scope>
-              </dependency>
-              <dependency>
-                  <groupId>io.micronaut</groupId>
-                  <artifactId>micronaut-http-server-netty</artifactId>
-                  <scope>compile</scope>
-              </dependency>
-              <dependency>
-                  <groupId>io.micronaut</groupId>
-                  <artifactId>micronaut-jackson-databind</artifactId>
-                  <scope>compile</scope>
-              </dependency>
-              <dependency>
-                  <groupId>io.micronaut</groupId>
-                  <artifactId>micronaut-validation</artifactId>
-                  <scope>compile</scope>
-              </dependency>
-              <dependency>
-                  <groupId>ch.qos.logback</groupId>
-                  <artifactId>logback-classic</artifactId>
-                  <scope>runtime</scope>
-              </dependency>
-          </dependencies>
-          <build>
-              <plugins>
-                  <plugin>
-                      <groupId>io.micronaut.build</groupId>
-                      <artifactId>micronaut-maven-plugin</artifactId>
-                  </plugin>
-                  <plugin>
-                      <groupId>org.apache.maven.plugins</groupId>
-                      <artifactId>maven-compiler-plugin</artifactId>
-                      <configuration>
-                          <annotationProcessorPaths combine.children="append">
-                              <path>
-                                  <groupId>io.micronaut</groupId>
-                                  <artifactId>micronaut-http-validation</artifactId>
-                                  <version>${micronaut.version}</version>
-                              </path>
-                          </annotationProcessorPaths>
-                          <compilerArgs>
-                              <arg>-Amicronaut.processing.group=com.example</arg>
-                              <arg>-Amicronaut.processing.module=demo</arg>
-                          </compilerArgs>
-                      </configuration>
-                  </plugin>
-              </plugins>
-          </build>
-      </project>
-      """;
-
-    @Language("xml")
-    private final String pomExpected = """
-      <project>
-          <groupId>com.mycompany.app</groupId>
-          <artifactId>my-app</artifactId>
-          <version>1</version>
-          <parent>
-              <groupId>io.micronaut.platform</groupId>
-              <artifactId>micronaut-parent</artifactId>
-              <version>4.0.0-RC1</version>
-          </parent>
-          <dependencies>
-              <dependency>
-                  <groupId>io.micronaut</groupId>
-                  <artifactId>micronaut-http-client</artifactId>
-                  <scope>compile</scope>
-              </dependency>
-              <dependency>
-                  <groupId>io.micronaut</groupId>
-                  <artifactId>micronaut-http-server-netty</artifactId>
-                  <scope>compile</scope>
-              </dependency>
-              <dependency>
-                  <groupId>io.micronaut</groupId>
-                  <artifactId>micronaut-jackson-databind</artifactId>
-                  <scope>compile</scope>
-              </dependency>
-              <dependency>
-                  <groupId>io.micronaut.validation</groupId>
-                  <artifactId>micronaut-validation</artifactId>
-                  <scope>compile</scope>
-              </dependency>
-              <dependency>
-                  <groupId>jakarta.validation</groupId>
-                  <artifactId>jakarta.validation-api</artifactId>
-              </dependency>
-              <dependency>
-                  <groupId>ch.qos.logback</groupId>
-                  <artifactId>logback-classic</artifactId>
-                  <scope>runtime</scope>
-              </dependency>
-          </dependencies>
-          <build>
-              <plugins>
-                  <plugin>
-                      <groupId>io.micronaut.build</groupId>
-                      <artifactId>micronaut-maven-plugin</artifactId>
-                  </plugin>
-                  <plugin>
-                      <groupId>org.apache.maven.plugins</groupId>
-                      <artifactId>maven-compiler-plugin</artifactId>
-                      <configuration>
-                          <annotationProcessorPaths combine.children="append">
-                              <path>
-                                  <groupId>io.micronaut.validation</groupId>
-                                  <artifactId>micronaut-validation-processor</artifactId>
-                                  <version>${micronaut.validation.version}</version>
-                                  <exclusions>
-                                      <exclusion>
-                                          <groupId>io.micronaut</groupId>
-                                          <artifactId>micronaut-inject</artifactId>
-                                      </exclusion>
-                                  </exclusions>
-                              </path>
-                          </annotationProcessorPaths>
-                          <compilerArgs>
-                              <arg>-Amicronaut.processing.group=com.example</arg>
-                              <arg>-Amicronaut.processing.module=demo</arg>
-                          </compilerArgs>
-                      </configuration>
-                  </plugin>
-              </plugins>
-          </build>
-      </project>
-      """;
+    //@Language("xml")
+    //private final String pomExpected = """
+    //  ;
 
 
     @Test
     void updateJavaCodeAndModifyGradleDependencies() {
-        rewriteRun(mavenProject("project", srcMainJava(java(annotatedJavaxClass, annotatedJakartaClass)),
-          buildGradle(buildGradleInitial, buildGradleExpected)));
+        rewriteRun(spec -> spec.beforeRecipe(withToolingApi()),
+          mavenProject("project", properties("micronautVersion=3.9.1", s -> s.path("gradle.properties")),
+            srcMainJava(java(annotatedJavaxClass, annotatedJakartaClass)),
+            //language=groovy
+            buildGradle("""
+              plugins {
+                  id("io.micronaut.application") version "3.7.10"
+              }
+                            
+              repositories {
+                  mavenCentral()
+              }
+                            
+              dependencies {
+                  annotationProcessor("io.micronaut:micronaut-http-validation")
+                  implementation("io.micronaut:micronaut-http-client")
+                  implementation("io.micronaut:micronaut-jackson-databind")
+                  implementation("io.micronaut:micronaut-validation")
+                  runtimeOnly("ch.qos.logback:logback-classic")
+              }
+              """, """
+              plugins {
+                  id("io.micronaut.application") version "4.0.0-M8"
+              }
+                            
+              repositories {
+                  mavenCentral()
+              }
+                            
+              dependencies {
+                  annotationProcessor("io.micronaut:micronaut-http-validation")
+                  annotationProcessor "io.micronaut.validation:micronaut-validation-processor"
+                  implementation("io.micronaut:micronaut-http-client")
+                  implementation("io.micronaut:micronaut-jackson-databind")
+                  implementation "io.micronaut.validation:micronaut-validation"
+                  runtimeOnly("ch.qos.logback:logback-classic")
+              }
+              """)));
+    }
+
+    @Test
+    void updateJavaCodeAndAddMissingGradleDependencies() {
+        rewriteRun(spec -> spec.beforeRecipe(withToolingApi()),
+          mavenProject("project", properties("micronautVersion=3.9.1", s -> s.path("gradle.properties")),
+            srcMainJava(java(annotatedJavaxClass, annotatedJakartaClass)),
+            //language=groovy
+            buildGradle("""
+              plugins {
+                  id("io.micronaut.application") version "3.7.10"
+              }
+                            
+              repositories {
+                  mavenCentral()
+              }
+                            
+              dependencies {
+                  annotationProcessor("io.micronaut:micronaut-http-validation")
+                  implementation("io.micronaut:micronaut-http-client")
+                  implementation("io.micronaut:micronaut-jackson-databind")
+                  runtimeOnly("ch.qos.logback:logback-classic")
+              }
+              """, """
+              plugins {
+                  id("io.micronaut.application") version "4.0.0-M8"
+              }
+                            
+              repositories {
+                  mavenCentral()
+              }
+                            
+              dependencies {
+                  annotationProcessor("io.micronaut:micronaut-http-validation")
+                  annotationProcessor "io.micronaut.validation:micronaut-validation-processor"
+                  implementation("io.micronaut:micronaut-http-client")
+                  implementation("io.micronaut:micronaut-jackson-databind")
+                  implementation "io.micronaut.validation:micronaut-validation"
+                  runtimeOnly("ch.qos.logback:logback-classic")
+              }
+              """)));
     }
 
     @Test
     void updateJavaCodeAndModifyMavenDependencies() {
         rewriteRun(mavenProject("project", srcMainJava(java(annotatedJavaxClass, annotatedJakartaClass)),
-          pomXml(pomInitial, pomExpected)));
+          //language=xml
+          pomXml("""
+            <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <parent>
+                    <groupId>io.micronaut</groupId>
+                    <artifactId>micronaut-parent</artifactId>
+                    <version>3.9.1</version>
+                </parent>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-http-client</artifactId>
+                        <scope>compile</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-http-server-netty</artifactId>
+                        <scope>compile</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-jackson-databind</artifactId>
+                        <scope>compile</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-validation</artifactId>
+                        <scope>compile</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                        <scope>runtime</scope>
+                    </dependency>
+                </dependencies>
+                <build>
+                    <plugins>
+                        <plugin>
+                            <groupId>io.micronaut.build</groupId>
+                            <artifactId>micronaut-maven-plugin</artifactId>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <configuration>
+                                <annotationProcessorPaths combine.children="append">
+                                    <path>
+                                        <groupId>io.micronaut</groupId>
+                                        <artifactId>micronaut-http-validation</artifactId>
+                                        <version>${micronaut.version}</version>
+                                    </path>
+                                </annotationProcessorPaths>
+                                <compilerArgs>
+                                    <arg>-Amicronaut.processing.group=com.example</arg>
+                                    <arg>-Amicronaut.processing.module=demo</arg>
+                                </compilerArgs>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </build>
+            </project>
+            """, """
+            <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <parent>
+                    <groupId>io.micronaut.platform</groupId>
+                    <artifactId>micronaut-parent</artifactId>
+                    <version>4.0.0-RC1</version>
+                </parent>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-http-client</artifactId>
+                        <scope>compile</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-http-server-netty</artifactId>
+                        <scope>compile</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-jackson-databind</artifactId>
+                        <scope>compile</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.micronaut.validation</groupId>
+                        <artifactId>micronaut-validation</artifactId>
+                    </dependency>
+                    <dependency>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                        <scope>runtime</scope>
+                    </dependency>
+                </dependencies>
+                <build>
+                    <plugins>
+                        <plugin>
+                            <groupId>io.micronaut.maven</groupId>
+                            <artifactId>micronaut-maven-plugin</artifactId>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <configuration>
+                                <annotationProcessorPaths combine.children="append">
+                                    <path>
+                                        <groupId>io.micronaut</groupId>
+                                        <artifactId>micronaut-http-validation</artifactId>
+                                        <version>${micronaut.version}</version>
+                                    </path>
+                                    <path>
+                                        <groupId>io.micronaut.validation</groupId>
+                                        <artifactId>micronaut-validation-processor</artifactId>
+                                        <version>${micronaut.validation.version}</version>
+                                        <exclusions>
+                                            <exclusion>
+                                                <groupId>io.micronaut</groupId>
+                                                <artifactId>micronaut-inject</artifactId>
+                                            </exclusion>
+                                        </exclusions>
+                                    </path>
+                                </annotationProcessorPaths>
+                                <compilerArgs>
+                                    <arg>-Amicronaut.processing.group=com.example</arg>
+                                    <arg>-Amicronaut.processing.module=demo</arg>
+                                </compilerArgs>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </build>
+            </project>
+            """)));
+    }
+
+    @Test
+    void updateJavaCodeAndAddMissingMavenDependencies() {
+        rewriteRun(mavenProject("project", srcMainJava(java(annotatedJavaxClass, annotatedJakartaClass)),
+          //language=xml
+          pomXml("""
+            <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <parent>
+                    <groupId>io.micronaut</groupId>
+                    <artifactId>micronaut-parent</artifactId>
+                    <version>3.9.1</version>
+                </parent>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-http-client</artifactId>
+                        <scope>compile</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-http-server-netty</artifactId>
+                        <scope>compile</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-jackson-databind</artifactId>
+                        <scope>compile</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                        <scope>runtime</scope>
+                    </dependency>
+                </dependencies>
+                <build>
+                    <plugins>
+                        <plugin>
+                            <groupId>io.micronaut.build</groupId>
+                            <artifactId>micronaut-maven-plugin</artifactId>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <configuration>
+                                <annotationProcessorPaths combine.children="append">
+                                    <path>
+                                        <groupId>io.micronaut</groupId>
+                                        <artifactId>micronaut-http-validation</artifactId>
+                                        <version>${micronaut.version}</version>
+                                    </path>
+                                </annotationProcessorPaths>
+                                <compilerArgs>
+                                    <arg>-Amicronaut.processing.group=com.example</arg>
+                                    <arg>-Amicronaut.processing.module=demo</arg>
+                                </compilerArgs>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </build>
+            </project>
+            """, """
+            <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <parent>
+                    <groupId>io.micronaut.platform</groupId>
+                    <artifactId>micronaut-parent</artifactId>
+                    <version>4.0.0-RC1</version>
+                </parent>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-http-client</artifactId>
+                        <scope>compile</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-http-server-netty</artifactId>
+                        <scope>compile</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-jackson-databind</artifactId>
+                        <scope>compile</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.micronaut.validation</groupId>
+                        <artifactId>micronaut-validation</artifactId>
+                    </dependency>
+                    <dependency>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                        <scope>runtime</scope>
+                    </dependency>
+                </dependencies>
+                <build>
+                    <plugins>
+                        <plugin>
+                            <groupId>io.micronaut.maven</groupId>
+                            <artifactId>micronaut-maven-plugin</artifactId>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <configuration>
+                                <annotationProcessorPaths combine.children="append">
+                                    <path>
+                                        <groupId>io.micronaut</groupId>
+                                        <artifactId>micronaut-http-validation</artifactId>
+                                        <version>${micronaut.version}</version>
+                                    </path>
+                                    <path>
+                                        <groupId>io.micronaut.validation</groupId>
+                                        <artifactId>micronaut-validation-processor</artifactId>
+                                        <version>${micronaut.validation.version}</version>
+                                        <exclusions>
+                                            <exclusion>
+                                                <groupId>io.micronaut</groupId>
+                                                <artifactId>micronaut-inject</artifactId>
+                                            </exclusion>
+                                        </exclusions>
+                                    </path>
+                                </annotationProcessorPaths>
+                                <compilerArgs>
+                                    <arg>-Amicronaut.processing.group=com.example</arg>
+                                    <arg>-Amicronaut.processing.module=demo</arg>
+                                </compilerArgs>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </build>
+            </project>
+            """)));
+    }
+
+    @Test
+    void updateJavaCodeAndLeaveExistingMavenAnnotationProcessor() {
+        rewriteRun(mavenProject("project", srcMainJava(java(annotatedJavaxClass, annotatedJakartaClass))),
+          //language=xml
+          pomXml("""
+            <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <parent>
+                    <groupId>io.micronaut.platform</groupId>
+                    <artifactId>micronaut-parent</artifactId>
+                    <version>4.0.0-RC1</version>
+                </parent>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-http-client</artifactId>
+                        <scope>compile</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-http-server-netty</artifactId>
+                        <scope>compile</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-jackson-databind</artifactId>
+                        <scope>compile</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.micronaut.validation</groupId>
+                        <artifactId>micronaut-validation</artifactId>
+                        <scope>compile</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                        <scope>runtime</scope>
+                    </dependency>
+                </dependencies>
+                <build>
+                    <plugins>
+                        <plugin>
+                            <groupId>io.micronaut.maven</groupId>
+                            <artifactId>micronaut-maven-plugin</artifactId>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <configuration>
+                                <annotationProcessorPaths combine.children="append">
+                                    <path>
+                                        <groupId>io.micronaut</groupId>
+                                        <artifactId>micronaut-http-validation</artifactId>
+                                        <version>${micronaut.version}</version>
+                                    </path>
+                                    <path>
+                                        <groupId>io.micronaut.validation</groupId>
+                                        <artifactId>micronaut-validation-processor</artifactId>
+                                        <version>${micronaut.validation.version}</version>
+                                        <exclusions>
+                                            <exclusion>
+                                                <groupId>io.micronaut</groupId>
+                                                <artifactId>micronaut-inject</artifactId>
+                                            </exclusion>
+                                        </exclusions>
+                                    </path>
+                                </annotationProcessorPaths>
+                                <compilerArgs>
+                                    <arg>-Amicronaut.processing.group=com.example</arg>
+                                    <arg>-Amicronaut.processing.module=demo</arg>
+                                </compilerArgs>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </build>
+            </project>
+            """));
     }
 }


### PR DESCRIPTION
## What's changed?
The recipe for upgrading Micronaut Validation has been revised such that:
- The existing micronaut-http-validation annotation processor configuration is preserved.
- The new micronaut-validation and micronaut-validation-processor modules are always applied if user code is using 
jakarta.validation constraints, whether or not micronaut-validation was previously configured in the build.
- The transitive jakarta.validation-api dependency is no longer erroneously added.

This resolves issue #61.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
