### PR TITLE
Remove withJansi from logback configuration.

### DIFF
--- a/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
+++ b/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
@@ -36,6 +36,7 @@ recipeList:
   - org.openrewrite.java.micronaut.AddMicronautRetryDependencyIfNeeded
   - org.openrewrite.java.micronaut.UpdateMicronautSecurity
   - org.openrewrite.java.micronaut.UpdateMicronautData
+  - org.openrewrite.java.micronaut.RemoveWithJansiLogbackConfiguration
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.micronaut.UpdateBuildToMicronaut4Version
@@ -346,3 +347,12 @@ recipeList:
   - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
       existingFullyQualifiedConstantName: io.micronaut.scheduling.TaskExecutors.IO
       fullyQualifiedConstantName: io.micronaut.scheduling.TaskExecutors.BLOCKING
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.micronaut.RemoveWithJansiLogbackConfiguration
+displayName: Remove withJansi Logback configuration
+description: This recipe will remove the withJansi configuration tag from logback.xml.
+recipeList:
+  - org.openrewrite.xml.RemoveXmlTag:
+      xPath: /configuration/appender/withJansi
+      fileMatcher: '**/logback.xml'

--- a/src/test/java/org/openrewrite/java/micronaut/RemoveWithJansiLogbackConfigurationTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/RemoveWithJansiLogbackConfigurationTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.micronaut;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.mavenProject;
+import static org.openrewrite.java.Assertions.srcMainResources;
+import static org.openrewrite.xml.Assertions.xml;
+
+public class RemoveWithJansiLogbackConfigurationTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResource("/META-INF/rewrite/micronaut3-to-4.yml", "org.openrewrite.java.micronaut.RemoveWithJansiLogbackConfiguration");
+    }
+
+    @Test
+    void removeWithJansi() {
+        rewriteRun(mavenProject("project", srcMainResources(
+          xml(//language=xml
+            """
+              <configuration>  
+                  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                      <withJansi>true</withJansi>
+                      <!-- encoders are assigned the type
+                           ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+                      <encoder>
+                          <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+                      </encoder>
+                  </appender>
+                  <root level="info">
+                      <appender-ref ref="STDOUT" />
+                  </root>
+              </configuration>
+              """,
+            //language=xml
+            """
+              <configuration>  
+                  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                      <!-- encoders are assigned the type
+                           ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+                      <encoder>
+                          <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+                      </encoder>
+                  </appender>
+                  <root level="info">
+                      <appender-ref ref="STDOUT" />
+                  </root>
+              </configuration>
+              """, s -> s.path("logback.xml")))));
+    }
+}


### PR DESCRIPTION
## What's changed?
Add a recipe to remove the `<withJansi>` tag from logback.xml.

This will resolve issue #59

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
