### PR TITLE
Ensure Gradle wrapper doesn't get added to Maven projects.

### DIFF
--- a/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
+++ b/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
@@ -23,6 +23,7 @@ recipeList:
   - org.openrewrite.java.migrate.JavaVersion17
   - org.openrewrite.gradle.UpdateGradleWrapper:
       version: 8.1.x
+      addIfMissing: false
   - org.openrewrite.java.micronaut.UpdateBuildToMicronaut4Version
   - org.openrewrite.java.micronaut.UpdateMicronautPlatformBom
   - org.openrewrite.java.micronaut.UpdateBuildPlugins


### PR DESCRIPTION
Configures `addIfMissing=false` on the `UpdateGradleWrapper` recipe so that a Gradle wrapper does not get added to 
Maven projects.
