### PR TITLE
Remove unnecessary micronaut-runtime dependency.

### DIFF
--- a/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
+++ b/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
@@ -38,6 +38,7 @@ recipeList:
   - org.openrewrite.java.micronaut.UpdateMicronautSecurity
   - org.openrewrite.java.micronaut.UpdateMicronautData
   - org.openrewrite.java.micronaut.RemoveWithJansiLogbackConfiguration
+  - org.openrewrite.java.micronaut.RemoveUnnecessaryDependencies
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.micronaut.UpdateBuildToMicronaut4Version

--- a/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
+++ b/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
@@ -353,3 +353,12 @@ recipeList:
   - org.openrewrite.xml.RemoveXmlTag:
       xPath: /configuration/appender/withJansi
       fileMatcher: '**/logback.xml'
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.micronaut.RemoveUnnecessaryDependencies
+displayName: Remove unnecessary dependencies
+description: This recipe will remove dependencies that are no longer explicitly needed.
+recipeList:
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: io.micronaut
+      artifactId: micronaut-runtime

--- a/src/test/java/org/openrewrite/java/micronaut/RemoveUnnecessaryDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/RemoveUnnecessaryDependenciesTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.micronaut;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.maven.MavenDownloadingException;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.SourceSpecs;
+
+import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.java.Assertions.mavenProject;
+import static org.openrewrite.maven.Assertions.pomXml;
+import static org.openrewrite.properties.Assertions.properties;
+
+public class RemoveUnnecessaryDependenciesTest implements RewriteTest {
+
+    private static String latestPluginVersion;
+
+    private static String latestMicronautVersion;
+
+    private static SourceSpecs gradleProperties;
+
+    @BeforeAll
+    static void init() throws MavenDownloadingException {
+        ExecutionContext ctx = new InMemoryExecutionContext();
+        latestPluginVersion = MicronautVersionHelper.getLatestMN4PluginVersion("io.micronaut.application");
+        latestMicronautVersion = MicronautVersionHelper.getLatestMN4Version();
+        gradleProperties = properties("micronautVersion=" + latestMicronautVersion, s -> s.path("gradle.properties"));
+    }
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResource("/META-INF/rewrite/micronaut3-to-4.yml", "org.openrewrite.java.micronaut.RemoveUnnecessaryDependencies");
+    }
+
+    @Test
+    void gradleDependenciesRemoved() {
+        rewriteRun(spec -> spec.beforeRecipe(withToolingApi()), mavenProject("project",
+          gradleProperties,
+          //language=groovy
+          buildGradle(String.format("""
+            plugins {
+                id("io.micronaut.application") version "%s"
+            }
+                        
+            repositories {
+                mavenCentral()
+            }
+                        
+            dependencies {
+                implementation "io.micronaut:micronaut-runtime"
+            }
+            """, latestPluginVersion), String.format("""
+            plugins {
+                id("io.micronaut.application") version "%s"
+            }
+                        
+            repositories {
+                mavenCentral()
+            }
+                        
+            dependencies {
+            }
+            """, latestPluginVersion))));
+    }
+
+    @Test
+    void mavenDependenciesRemoved() {
+        rewriteRun(mavenProject("project",
+          //language=xml
+          pomXml(String.format("""
+            <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <parent>
+                    <groupId>io.micronaut.platform</groupId>
+                    <artifactId>micronaut-parent</artifactId>
+                    <version>%s</version>
+                </parent>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-runtime</artifactId>
+                    </dependency>
+                </dependencies>
+            </project>
+            """, latestMicronautVersion), String.format("""
+            <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <parent>
+                    <groupId>io.micronaut.platform</groupId>
+                    <artifactId>micronaut-parent</artifactId>
+                    <version>%s</version>
+                </parent>
+            </project>
+            """, latestMicronautVersion))));
+    }
+}


### PR DESCRIPTION
## What's changed?
Add a `RemoveUnnecessaryDependencies` recipe that initially just removes micronaut-runtime for Micronaut Framework 
4.0.0 applications.

Resolves issue #76

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
