### PR TITLE
Refactor tests to dynamically resolve and match versions.

### DIFF
--- a/src/main/java/org/openrewrite/java/micronaut/MicronautVersionHelper.java
+++ b/src/main/java/org/openrewrite/java/micronaut/MicronautVersionHelper.java
@@ -41,6 +41,22 @@ public final class MicronautVersionHelper {
 
     public static final MavenRepository GRADLE_PLUGIN_REPO = new MavenRepository("gradle-plugins", "https://plugins.gradle.org/m2/", "true", "false", true, null, null, true);
 
+    public static final String getLatestMN2Version() {
+        try {
+            return getNewerVersion("2.x", "2.0.0", new InMemoryExecutionContext()).orElse("2.0.0");
+        } catch (MavenDownloadingException e) {
+            throw new IllegalStateException("Failed to resolve latest Micronaut Framework 2.x version", e);
+        }
+    }
+
+    public static final String getLatestMN3Version() {
+        try {
+            return getNewerVersion("3.x", "3.0.0", new InMemoryExecutionContext()).orElse("3.0.0");
+        } catch (MavenDownloadingException e) {
+            throw new IllegalStateException("Failed to resolve latest Micronaut Framework 3.x version", e);
+        }
+    }
+
     public static final String getLatestMN4Version() {
         try {
             return getNewerVersion("4.x", "4.0.0", new InMemoryExecutionContext()).orElse("4.0.0");

--- a/src/test/java/org/openrewrite/java/micronaut/AddMicronautRetryDependencyIfNeededTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/AddMicronautRetryDependencyIfNeededTest.java
@@ -20,107 +20,94 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
-import org.openrewrite.test.RewriteTest;
-import org.openrewrite.test.SourceSpecs;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
-import static org.openrewrite.properties.Assertions.properties;
 
-public class AddMicronautRetryDependencyIfNeededTest implements RewriteTest {
+public class AddMicronautRetryDependencyIfNeededTest extends Micronaut4RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),"jakarta.inject-api-2.*", "micronaut-retry-4.*"));
+        spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "jakarta.inject-api-2.*", "micronaut-retry-4.*"));
         spec.recipeFromResource("/META-INF/rewrite/micronaut3-to-4.yml", "org.openrewrite.java.micronaut.AddMicronautRetryDependencyIfNeeded");
     }
 
     @Language("java")
     private final String retryableService = """
-            import jakarta.inject.Singleton;
-            import io.micronaut.retry.annotation.Retryable;
-            
-            @Singleton
-            public class PersonService {
-            
-                @Retryable
-                public void callFlakyRemote() {
-                    
-                }
-            }
-        """;
-
-    private final SourceSpecs gradleProperties = properties("micronautVersion=4.0.0", s -> s.path("gradle.properties"));
-
-    @Language("groovy")
-    private final String buildGradleInitial = """
-            plugins {
-                id("io.micronaut.application") version "4.0.0"
-            }
-            
-            repositories {
-                mavenCentral()
-            }
-        """;
-
-    @Language("groovy")
-    private final String buildGradleExpected = """
-            plugins {
-                id("io.micronaut.application") version "4.0.0"
-            }
-            
-            repositories {
-                mavenCentral()
-            }
-            
-            dependencies {
-                implementation "io.micronaut:micronaut-retry"
-            }
-        """;
-
-    @Language("xml")
-    private final String pomInitial = """
-            <project>
-                <groupId>com.mycompany.app</groupId>
-                <artifactId>my-app</artifactId>
-                <version>1</version>
-                <parent>
-                    <groupId>io.micronaut.platform</groupId>
-                    <artifactId>micronaut-parent</artifactId>
-                    <version>4.0.0</version>
-                </parent>
-            </project>
-        """;
-
-    @Language("xml")
-    private final String pomExpected = """
-            <project>
-                <groupId>com.mycompany.app</groupId>
-                <artifactId>my-app</artifactId>
-                <version>1</version>
-                <parent>
-                    <groupId>io.micronaut.platform</groupId>
-                    <artifactId>micronaut-parent</artifactId>
-                    <version>4.0.0</version>
-                </parent>
-                <dependencies>
-                    <dependency>
-                        <groupId>io.micronaut</groupId>
-                        <artifactId>micronaut-retry</artifactId>
-                    </dependency>
-                </dependencies>
-            </project>
-        """;
+          import jakarta.inject.Singleton;
+          import io.micronaut.retry.annotation.Retryable;
+          
+          @Singleton
+          public class PersonService {
+          
+              @Retryable
+              public void callFlakyRemote() {
+                  
+              }
+          }
+      """;
 
     @Test
     void updateGradleDependencies() {
-        rewriteRun(spec -> spec.beforeRecipe(withToolingApi()), mavenProject("project", srcMainJava(java(retryableService)), gradleProperties, buildGradle(buildGradleInitial, buildGradleExpected)));
+        rewriteRun(spec -> spec.beforeRecipe(withToolingApi()), mavenProject("project", srcMainJava(java(retryableService)), getGradleProperties(),
+          //language=groovy
+          buildGradle(String.format("""
+                plugins {
+                    id("io.micronaut.application") version "%s"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+            """, latestApplicationPluginVersion), String.format("""
+                plugins {
+                    id("io.micronaut.application") version "%s"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
+                dependencies {
+                    implementation "io.micronaut:micronaut-retry"
+                }
+            """, latestApplicationPluginVersion))));
     }
 
     @Test
     void updateMavenDependencies() {
-        rewriteRun(mavenProject("project", srcMainJava(java(retryableService)), pomXml(pomInitial, pomExpected)));
+        rewriteRun(mavenProject("project", srcMainJava(java(retryableService)),
+          //language=xml
+          pomXml(String.format("""
+                <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <parent>
+                        <groupId>io.micronaut.platform</groupId>
+                        <artifactId>micronaut-parent</artifactId>
+                        <version>%s</version>
+                    </parent>
+                </project>
+            """, latestMicronautVersion), String.format("""
+                <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <parent>
+                        <groupId>io.micronaut.platform</groupId>
+                        <artifactId>micronaut-parent</artifactId>
+                        <version>%s</version>
+                    </parent>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.micronaut</groupId>
+                            <artifactId>micronaut-retry</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+            """, latestMicronautVersion))));
     }
 }

--- a/src/test/java/org/openrewrite/java/micronaut/AddMicronautWebsocketDependencyIfNeededTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/AddMicronautWebsocketDependencyIfNeededTest.java
@@ -20,16 +20,13 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
-import org.openrewrite.test.RewriteTest;
-import org.openrewrite.test.SourceSpecs;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
-import static org.openrewrite.properties.Assertions.properties;
 
-public class AddMicronautWebsocketDependencyIfNeededTest implements RewriteTest {
+public class AddMicronautWebsocketDependencyIfNeededTest extends Micronaut4RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
@@ -39,89 +36,79 @@ public class AddMicronautWebsocketDependencyIfNeededTest implements RewriteTest 
 
     @Language("java")
     private final String annotatedWebsocketClass = """
-            import io.micronaut.websocket.WebSocketBroadcaster;
-            import io.micronaut.websocket.annotation.ServerWebSocket;       
-            
-            @ServerWebSocket("/chat/{topic}/{username}")
-            public class ChatServerWebSocket {
-            
-                private final WebSocketBroadcaster broadcaster;
-                
-                public ChatServerWebSocket(WebSocketBroadcaster broadcaster) {
-                    this.broadcaster = broadcaster;
-                }
-            }
-        """;
-
-    private final SourceSpecs gradleProperties = properties("micronautVersion=4.0.0-RC1", s -> s.path("gradle.properties"));
-
-    @Language("groovy")
-    private final String buildGradleInitial = """
-            plugins {
-                id("io.micronaut.application") version "4.0.0"
-            }
-            
-            repositories {
-                mavenCentral()
-            }
-        """;
-
-    @Language("groovy")
-    private final String buildGradleExpected = """
-            plugins {
-                id("io.micronaut.application") version "4.0.0"
-            }
-            
-            repositories {
-                mavenCentral()
-            }
-            
-            dependencies {
-                implementation "io.micronaut:micronaut-websocket"
-            }
-        """;
-
-    @Language("xml")
-    private final String pomInitial = """
-            <project>
-                <groupId>com.mycompany.app</groupId>
-                <artifactId>my-app</artifactId>
-                <version>1</version>
-                <parent>
-                    <groupId>io.micronaut.platform</groupId>
-                    <artifactId>micronaut-parent</artifactId>
-                    <version>4.0.0</version>
-                </parent>
-            </project>
-        """;
-
-    @Language("xml")
-    private final String pomExpected = """
-            <project>
-                <groupId>com.mycompany.app</groupId>
-                <artifactId>my-app</artifactId>
-                <version>1</version>
-                <parent>
-                    <groupId>io.micronaut.platform</groupId>
-                    <artifactId>micronaut-parent</artifactId>
-                    <version>4.0.0</version>
-                </parent>
-                <dependencies>
-                    <dependency>
-                        <groupId>io.micronaut</groupId>
-                        <artifactId>micronaut-websocket</artifactId>
-                    </dependency>
-                </dependencies>
-            </project>
-        """;
+          import io.micronaut.websocket.WebSocketBroadcaster;
+          import io.micronaut.websocket.annotation.ServerWebSocket;       
+          
+          @ServerWebSocket("/chat/{topic}/{username}")
+          public class ChatServerWebSocket {
+          
+              private final WebSocketBroadcaster broadcaster;
+              
+              public ChatServerWebSocket(WebSocketBroadcaster broadcaster) {
+                  this.broadcaster = broadcaster;
+              }
+          }
+      """;
 
     @Test
     void updateGradleDependencies() {
-        rewriteRun(spec -> spec.beforeRecipe(withToolingApi()), mavenProject("project", srcMainJava(java(annotatedWebsocketClass)), gradleProperties, buildGradle(buildGradleInitial, buildGradleExpected)));
+        rewriteRun(spec -> spec.beforeRecipe(withToolingApi()), mavenProject("project", srcMainJava(java(annotatedWebsocketClass)), getGradleProperties(),
+          //language=groovy
+          buildGradle(String.format("""
+                plugins {
+                    id("io.micronaut.application") version "%s"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+            """, latestApplicationPluginVersion), String.format("""
+                plugins {
+                    id("io.micronaut.application") version "%s"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
+                dependencies {
+                    implementation "io.micronaut:micronaut-websocket"
+                }
+            """, latestApplicationPluginVersion))));
     }
 
     @Test
     void updateMavenDependencies() {
-        rewriteRun(mavenProject("project", srcMainJava(java(annotatedWebsocketClass)), pomXml(pomInitial, pomExpected)));
+        rewriteRun(mavenProject("project", srcMainJava(java(annotatedWebsocketClass)),
+          //language=xml
+          pomXml(String.format("""
+                <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <parent>
+                        <groupId>io.micronaut.platform</groupId>
+                        <artifactId>micronaut-parent</artifactId>
+                        <version>%s</version>
+                    </parent>
+                </project>
+            """, latestMicronautVersion), String.format("""
+                <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <parent>
+                        <groupId>io.micronaut.platform</groupId>
+                        <artifactId>micronaut-parent</artifactId>
+                        <version>%s</version>
+                    </parent>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.micronaut</groupId>
+                            <artifactId>micronaut-websocket</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+            """, latestMicronautVersion))));
     }
 }

--- a/src/test/java/org/openrewrite/java/micronaut/AddSnakeYamlDependencyIfNeededTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/AddSnakeYamlDependencyIfNeededTest.java
@@ -20,8 +20,6 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
-import org.openrewrite.test.RewriteTest;
-import org.openrewrite.test.SourceSpecs;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.Assertions.withToolingApi;
@@ -30,7 +28,7 @@ import static org.openrewrite.maven.Assertions.pomXml;
 import static org.openrewrite.properties.Assertions.properties;
 import static org.openrewrite.yaml.Assertions.yaml;
 
-public class AddSnakeYamlDependencyIfNeededTest implements RewriteTest {
+public class AddSnakeYamlDependencyIfNeededTest extends Micronaut4RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
@@ -51,33 +49,33 @@ public class AddSnakeYamlDependencyIfNeededTest implements RewriteTest {
 
     @Language("yml")
     private final String micronautConfig = """
-        micronaut:
-            application:
-                name: testApp
-        """;
+      micronaut:
+          application:
+              name: testApp
+      """;
 
     @Language("properties")
     private final String micronautPropertiesConfig = """
-            micronaut.application.name=testApp
-        """;
+          micronaut.application.name=testApp
+      """;
 
-    private final SourceSpecs gradleProperties = properties("micronautVersion=4.0.0", s -> s.path("gradle.properties"));
-
-    @Language("groovy")
-    private final String buildGradleNoDependency = """
+    private final String buildGradleNoDependency =
+      //language=groovy
+      String.format("""
             plugins {
-                id("io.micronaut.application") version "4.0.0"
+                id("io.micronaut.application") version "%s"
             }
             
             repositories {
                 mavenCentral()
             }
-        """;
+        """, latestApplicationPluginVersion);
 
-    @Language("groovy")
-    private final String buildGradleWithDependency = """
+    private final String buildGradleWithDependency =
+      //language=groovy
+      String.format("""
             plugins {
-                id("io.micronaut.application") version "4.0.0"
+                id("io.micronaut.application") version "%s"
             }
             
             repositories {
@@ -87,10 +85,11 @@ public class AddSnakeYamlDependencyIfNeededTest implements RewriteTest {
             dependencies {
                 runtimeOnly "org.yaml:snakeyaml"
             }
-        """;
+        """, latestApplicationPluginVersion);
 
-    @Language("xml")
-    private final String initialPom = """
+    private final String initialPom =
+      //language=xml
+      String.format("""
             <project>
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
@@ -98,13 +97,14 @@ public class AddSnakeYamlDependencyIfNeededTest implements RewriteTest {
                 <parent>
                     <groupId>io.micronaut.platform</groupId>
                     <artifactId>micronaut-parent</artifactId>
-                    <version>4.0.0</version>
+                    <version>%s</version>
                 </parent>
             </project>
-        """;
+        """, latestMicronautVersion);
 
-    @Language("xml")
-    private final String pomWithDependency = """
+    private final String pomWithDependency =
+      //language=xml
+      String.format("""
             <project>
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
@@ -112,7 +112,7 @@ public class AddSnakeYamlDependencyIfNeededTest implements RewriteTest {
                 <parent>
                     <groupId>io.micronaut.platform</groupId>
                     <artifactId>micronaut-parent</artifactId>
-                    <version>4.0.0</version>
+                    <version>%s</version>
                 </parent>
                 <dependencies>
                     <dependency>
@@ -122,159 +122,159 @@ public class AddSnakeYamlDependencyIfNeededTest implements RewriteTest {
                     </dependency>
                 </dependencies>
             </project>
-        """;
+        """, latestMicronautVersion);
 
     @Test
     void testAddGradleDependencyForApplicationYml() {
         rewriteRun(spec -> spec.beforeRecipe(withToolingApi()).recipe(new AddSnakeYamlDependencyIfNeeded()), mavenProject("project",
-                srcMainJava(java(micronautApplication)),
-                srcMainResources(yaml(micronautConfig, s -> s.path("application.yml"))),
-                gradleProperties,
-                buildGradle(buildGradleNoDependency, buildGradleWithDependency)));
+          srcMainJava(java(micronautApplication)),
+          srcMainResources(yaml(micronautConfig, s -> s.path("application.yml"))),
+          getGradleProperties(),
+          buildGradle(buildGradleNoDependency, buildGradleWithDependency)));
     }
 
     @Test
     void testAddMavenDependencyForApplicationYml() {
         rewriteRun(spec -> spec.recipe(new AddSnakeYamlDependencyIfNeeded()), mavenProject("project",
-                srcMainJava(java(micronautApplication)),
-                srcMainResources(yaml(micronautConfig, s -> s.path("application.yml"))),
-                pomXml(initialPom, pomWithDependency)));
+          srcMainJava(java(micronautApplication)),
+          srcMainResources(yaml(micronautConfig, s -> s.path("application.yml"))),
+          pomXml(initialPom, pomWithDependency)));
     }
 
     @Test
     void testAddGradleDependencyForApplicationYaml() {
         rewriteRun(spec -> spec.beforeRecipe(withToolingApi()).recipe(new AddSnakeYamlDependencyIfNeeded()), mavenProject("project",
-                srcMainJava(java(micronautApplication)),
-                srcMainResources(yaml(micronautConfig, s -> s.path("application.yaml"))),
-                gradleProperties,
-                buildGradle(buildGradleNoDependency, buildGradleWithDependency)));
+          srcMainJava(java(micronautApplication)),
+          srcMainResources(yaml(micronautConfig, s -> s.path("application.yaml"))),
+          getGradleProperties(),
+          buildGradle(buildGradleNoDependency, buildGradleWithDependency)));
     }
 
     @Test
     void testAddMavenDependencyForApplicationYaml() {
         rewriteRun(spec -> spec.recipe(new AddSnakeYamlDependencyIfNeeded()), mavenProject("project",
-                srcMainJava(java(micronautApplication)),
-                srcMainResources(yaml(micronautConfig, s -> s.path("application.yaml"))),
-                pomXml(initialPom, pomWithDependency)));
+          srcMainJava(java(micronautApplication)),
+          srcMainResources(yaml(micronautConfig, s -> s.path("application.yaml"))),
+          pomXml(initialPom, pomWithDependency)));
     }
 
 
     @Test
     void testNoGradleDependencyForMissingApplicationYml() {
         rewriteRun(spec -> spec.beforeRecipe(withToolingApi()).recipe(new AddSnakeYamlDependencyIfNeeded()), mavenProject("project",
-                srcMainJava(java(micronautApplication)),
-                srcMainResources(yaml(micronautConfig, s -> s.path("foo.yml"))),
-                gradleProperties,
-                buildGradle(buildGradleNoDependency)));
+          srcMainJava(java(micronautApplication)),
+          srcMainResources(yaml(micronautConfig, s -> s.path("foo.yml"))),
+          getGradleProperties(),
+          buildGradle(buildGradleNoDependency)));
     }
 
     @Test
     void testNoMavenDependencyForMissingApplicationYml() {
         rewriteRun(spec -> spec.recipe(new AddSnakeYamlDependencyIfNeeded()), mavenProject("project",
-                srcMainJava(java(micronautApplication)),
-                srcMainResources(yaml(micronautConfig, s -> s.path("foo.yml"))),
-                pomXml(initialPom)));
+          srcMainJava(java(micronautApplication)),
+          srcMainResources(yaml(micronautConfig, s -> s.path("foo.yml"))),
+          pomXml(initialPom)));
     }
 
     @Test
     void testNoGradleDependencyForApplicationProperties() {
         rewriteRun(spec -> spec.beforeRecipe(withToolingApi()).recipe(new AddSnakeYamlDependencyIfNeeded()), mavenProject("project",
-                srcMainJava(java(micronautApplication)),
-                srcMainResources(properties(micronautPropertiesConfig, s -> s.path("application.properties"))),
-                gradleProperties,
-                buildGradle(buildGradleNoDependency)));
+          srcMainJava(java(micronautApplication)),
+          srcMainResources(properties(micronautPropertiesConfig, s -> s.path("application.properties"))),
+          getGradleProperties(),
+          buildGradle(buildGradleNoDependency)));
     }
 
     @Test
     void testNoMavenDependencyForApplicationProperties() {
         rewriteRun(spec -> spec.recipe(new AddSnakeYamlDependencyIfNeeded()), mavenProject("project",
-                srcMainJava(java(micronautApplication)),
-                srcMainResources(properties(micronautPropertiesConfig, s -> s.path("application.properties"))),
-                pomXml(initialPom)));
+          srcMainJava(java(micronautApplication)),
+          srcMainResources(properties(micronautPropertiesConfig, s -> s.path("application.properties"))),
+          pomXml(initialPom)));
     }
 
     @Test
     void testExistingGradleDependencyUnchanged() {
         rewriteRun(spec -> spec.beforeRecipe(withToolingApi()).recipe(new AddSnakeYamlDependencyIfNeeded()), mavenProject("project",
-                srcMainJava(java(micronautApplication)),
-                srcMainResources(yaml(micronautConfig, s -> s.path("application.yml"))),
-                gradleProperties,
-                buildGradle(buildGradleWithDependency)));
+          srcMainJava(java(micronautApplication)),
+          srcMainResources(yaml(micronautConfig, s -> s.path("application.yml"))),
+          getGradleProperties(),
+          buildGradle(buildGradleWithDependency)));
     }
 
     @Test
     void testExistingMavenDependencyUnchanged() {
         rewriteRun(spec -> spec.recipe(new AddSnakeYamlDependencyIfNeeded()), mavenProject("project",
-                srcMainJava(java(micronautApplication)),
-                srcMainResources(yaml(micronautConfig, s -> s.path("application.yml"))),
-                pomXml(pomWithDependency)));
+          srcMainJava(java(micronautApplication)),
+          srcMainResources(yaml(micronautConfig, s -> s.path("application.yml"))),
+          pomXml(pomWithDependency)));
     }
 
     @Test
     void testAddGradleDependencyForEnvironmentYml() {
         rewriteRun(spec -> spec.beforeRecipe(withToolingApi()).recipe(new AddSnakeYamlDependencyIfNeeded()), mavenProject("project",
-                srcMainJava(java(micronautApplication)),
-                srcMainResources(yaml(micronautConfig, s -> s.path("application-foo.yml"))),
-                gradleProperties,
-                buildGradle(buildGradleNoDependency, buildGradleWithDependency)));
+          srcMainJava(java(micronautApplication)),
+          srcMainResources(yaml(micronautConfig, s -> s.path("application-foo.yml"))),
+          getGradleProperties(),
+          buildGradle(buildGradleNoDependency, buildGradleWithDependency)));
     }
 
     @Test
     void testAddMavenDependencyForEnvironmentYml() {
         rewriteRun(spec -> spec.recipe(new AddSnakeYamlDependencyIfNeeded()), mavenProject("project",
-                srcMainJava(java(micronautApplication)),
-                srcMainResources(yaml(micronautConfig, s -> s.path("application-foo.yml"))),
-                pomXml(initialPom, pomWithDependency)));
+          srcMainJava(java(micronautApplication)),
+          srcMainResources(yaml(micronautConfig, s -> s.path("application-foo.yml"))),
+          pomXml(initialPom, pomWithDependency)));
     }
 
     @Test
     void testAddGradleDependencyForTestYml() {
         rewriteRun(spec -> spec.beforeRecipe(withToolingApi()).recipe(new AddSnakeYamlDependencyIfNeeded()), mavenProject("project",
-                srcMainJava(java(micronautApplication)),
-                srcTestResources(yaml(micronautConfig, s -> s.path("application-test.yml"))),
-                gradleProperties,
-                buildGradle(buildGradleNoDependency, buildGradleWithDependency)));
+          srcMainJava(java(micronautApplication)),
+          srcTestResources(yaml(micronautConfig, s -> s.path("application-test.yml"))),
+          getGradleProperties(),
+          buildGradle(buildGradleNoDependency, buildGradleWithDependency)));
     }
 
     @Test
     void testAddMavenDependencyForTestYml() {
         rewriteRun(spec -> spec.recipe(new AddSnakeYamlDependencyIfNeeded()), mavenProject("project",
-                srcMainJava(java(micronautApplication)),
-                srcTestResources(yaml(micronautConfig, s -> s.path("application-test.yml"))),
-                pomXml(initialPom, pomWithDependency)));
+          srcMainJava(java(micronautApplication)),
+          srcTestResources(yaml(micronautConfig, s -> s.path("application-test.yml"))),
+          pomXml(initialPom, pomWithDependency)));
     }
 
     @Test
     void testAddGradleDependencyForBootstrapYml() {
         rewriteRun(spec -> spec.beforeRecipe(withToolingApi()).recipe(new AddSnakeYamlDependencyIfNeeded()), mavenProject("project",
-                srcMainJava(java(micronautApplication)),
-                srcMainResources(yaml(micronautConfig, s -> s.path("bootstrap.yml"))),
-                gradleProperties,
-                buildGradle(buildGradleNoDependency, buildGradleWithDependency)));
+          srcMainJava(java(micronautApplication)),
+          srcMainResources(yaml(micronautConfig, s -> s.path("bootstrap.yml"))),
+          getGradleProperties(),
+          buildGradle(buildGradleNoDependency, buildGradleWithDependency)));
     }
 
     @Test
     void testAddMavenDependencyForBootstrapYml() {
         rewriteRun(spec -> spec.recipe(new AddSnakeYamlDependencyIfNeeded()), mavenProject("project",
-                srcMainJava(java(micronautApplication)),
-                srcMainResources(yaml(micronautConfig, s -> s.path("bootstrap.yml"))),
-                pomXml(initialPom, pomWithDependency)));
+          srcMainJava(java(micronautApplication)),
+          srcMainResources(yaml(micronautConfig, s -> s.path("bootstrap.yml"))),
+          pomXml(initialPom, pomWithDependency)));
     }
 
     @Test
     void testAddGradleDependencyForBootstrapEnvironmentYml() {
         rewriteRun(spec -> spec.beforeRecipe(withToolingApi()).recipe(new AddSnakeYamlDependencyIfNeeded()), mavenProject("project",
-                srcMainJava(java(micronautApplication)),
-                srcMainResources(yaml(micronautConfig, s -> s.path("bootstrap-foo.yml"))),
-                gradleProperties,
-                buildGradle(buildGradleNoDependency, buildGradleWithDependency)));
+          srcMainJava(java(micronautApplication)),
+          srcMainResources(yaml(micronautConfig, s -> s.path("bootstrap-foo.yml"))),
+          getGradleProperties(),
+          buildGradle(buildGradleNoDependency, buildGradleWithDependency)));
     }
 
     @Test
     void testAddMavenDependencyForBootstrapEnvironmentYml() {
         rewriteRun(spec -> spec.recipe(new AddSnakeYamlDependencyIfNeeded()), mavenProject("project",
-                srcMainJava(java(micronautApplication)),
-                srcMainResources(yaml(micronautConfig, s -> s.path("bootstrap-foo.yml"))),
-                pomXml(initialPom, pomWithDependency)));
+          srcMainJava(java(micronautApplication)),
+          srcMainResources(yaml(micronautConfig, s -> s.path("bootstrap-foo.yml"))),
+          pomXml(initialPom, pomWithDependency)));
     }
 }

--- a/src/test/java/org/openrewrite/java/micronaut/Micronaut4RewriteTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/Micronaut4RewriteTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.micronaut;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.openrewrite.maven.MavenDownloadingException;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.SourceSpecs;
+
+import static org.openrewrite.properties.Assertions.properties;
+
+public abstract class Micronaut4RewriteTest implements RewriteTest {
+    protected static String latestApplicationPluginVersion;
+    protected static String latestMicronautVersion;
+    private SourceSpecs gradleProperties;
+
+    @BeforeAll
+    static void init() throws MavenDownloadingException {
+        latestApplicationPluginVersion = MicronautVersionHelper.getLatestMN4PluginVersion("io.micronaut.application");
+        latestMicronautVersion = MicronautVersionHelper.getLatestMN4Version();
+    }
+
+    @BeforeEach
+    void initGradleProperties() {
+       gradleProperties = properties("micronautVersion=" + latestMicronautVersion, s -> s.path("gradle.properties"));
+    }
+
+    protected SourceSpecs getGradleProperties() {
+        return gradleProperties;
+    }
+}

--- a/src/test/java/org/openrewrite/java/micronaut/RemoveUnnecessaryDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/RemoveUnnecessaryDependenciesTest.java
@@ -15,36 +15,15 @@
  */
 package org.openrewrite.java.micronaut;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.InMemoryExecutionContext;
-import org.openrewrite.maven.MavenDownloadingException;
 import org.openrewrite.test.RecipeSpec;
-import org.openrewrite.test.RewriteTest;
-import org.openrewrite.test.SourceSpecs;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
-import static org.openrewrite.properties.Assertions.properties;
 
-public class RemoveUnnecessaryDependenciesTest implements RewriteTest {
-
-    private static String latestPluginVersion;
-
-    private static String latestMicronautVersion;
-
-    private static SourceSpecs gradleProperties;
-
-    @BeforeAll
-    static void init() throws MavenDownloadingException {
-        ExecutionContext ctx = new InMemoryExecutionContext();
-        latestPluginVersion = MicronautVersionHelper.getLatestMN4PluginVersion("io.micronaut.application");
-        latestMicronautVersion = MicronautVersionHelper.getLatestMN4Version();
-        gradleProperties = properties("micronautVersion=" + latestMicronautVersion, s -> s.path("gradle.properties"));
-    }
+public class RemoveUnnecessaryDependenciesTest extends Micronaut4RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
@@ -54,7 +33,7 @@ public class RemoveUnnecessaryDependenciesTest implements RewriteTest {
     @Test
     void gradleDependenciesRemoved() {
         rewriteRun(spec -> spec.beforeRecipe(withToolingApi()), mavenProject("project",
-          gradleProperties,
+          getGradleProperties(),
           //language=groovy
           buildGradle(String.format("""
             plugins {
@@ -68,7 +47,7 @@ public class RemoveUnnecessaryDependenciesTest implements RewriteTest {
             dependencies {
                 implementation "io.micronaut:micronaut-runtime"
             }
-            """, latestPluginVersion), String.format("""
+            """, latestApplicationPluginVersion), String.format("""
             plugins {
                 id("io.micronaut.application") version "%s"
             }
@@ -79,7 +58,7 @@ public class RemoveUnnecessaryDependenciesTest implements RewriteTest {
                         
             dependencies {
             }
-            """, latestPluginVersion))));
+            """, latestApplicationPluginVersion))));
     }
 
     @Test

--- a/src/test/java/org/openrewrite/java/micronaut/UpdateBuildPluginsTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpdateBuildPluginsTest.java
@@ -18,7 +18,6 @@ package org.openrewrite.java.micronaut;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
-import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.Assertions.withToolingApi;
@@ -26,19 +25,17 @@ import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 import static org.openrewrite.properties.Assertions.properties;
 
-public class UpdateBuildPluginsTest implements RewriteTest {
+public class UpdateBuildPluginsTest extends Micronaut4RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipeFromResource("/META-INF/rewrite/micronaut3-to-4.yml", "org.openrewrite.java.micronaut.UpdateMicronautPlatformBom",
-          "org.openrewrite.java.micronaut.UpdateBuildPlugins");
+        spec.recipeFromResource("/META-INF/rewrite/micronaut3-to-4.yml", "org.openrewrite.java.micronaut.UpdateMicronautPlatformBom", "org.openrewrite.java.micronaut.UpdateBuildPlugins");
     }
 
     @DocumentExample
     @Test
     void updateGradleBuildPlugins() {
-        rewriteRun(spec -> spec.beforeRecipe(withToolingApi()),
-          properties("micronautVersion=3.9.1", s -> s.path("gradle.properties")),
+        rewriteRun(spec -> spec.beforeRecipe(withToolingApi()), properties("micronautVersion=3.9.1", s -> s.path("gradle.properties")),
           //language=groovy
           buildGradle("""
                 plugins {
@@ -58,69 +55,69 @@ public class UpdateBuildPluginsTest implements RewriteTest {
                 repositories {
                     mavenCentral()
                 }
-            """, """
+            """, String.format("""
                 plugins {
                     id("com.github.johnrengelman.shadow") version "8.1.1"
-                    id("io.micronaut.application") version "4.0.0"
-                    id("io.micronaut.minimal.application") version "4.0.0"
-                    id("io.micronaut.aot") version "4.0.0"
-                    id("io.micronaut.component") version "4.0.0"
-                    id("io.micronaut.crac") version "4.0.0"
-                    id("io.micronaut.docker") version "4.0.0"
-                    id("io.micronaut.graalvm") version "4.0.0"
-                    id("io.micronaut.library") version "4.0.0"
-                    id("io.micronaut.minimal.library") version "4.0.0"
-                    id("io.micronaut.test-resources") version "4.0.0"
+                    id("io.micronaut.application") version "%s"
+                    id("io.micronaut.minimal.application") version "%s"
+                    id("io.micronaut.aot") version "%s"
+                    id("io.micronaut.component") version "%s"
+                    id("io.micronaut.crac") version "%s"
+                    id("io.micronaut.docker") version "%s"
+                    id("io.micronaut.graalvm") version "%s"
+                    id("io.micronaut.library") version "%s"
+                    id("io.micronaut.minimal.library") version "%s"
+                    id("io.micronaut.test-resources") version "%s"
                 }
                 
                 repositories {
                     mavenCentral()
                 }
-            """));
+            """, latestApplicationPluginVersion, MicronautVersionHelper.getLatestMN4PluginVersion("io.micronaut.minimal.application"), MicronautVersionHelper.getLatestMN4PluginVersion("io.micronaut.aot"), MicronautVersionHelper.getLatestMN4PluginVersion("io.micronaut.component"), MicronautVersionHelper.getLatestMN4PluginVersion("io.micronaut.crac"), MicronautVersionHelper.getLatestMN4PluginVersion("io.micronaut.docker"), MicronautVersionHelper.getLatestMN4PluginVersion("io.micronaut.graalvmn"), MicronautVersionHelper.getLatestMN4PluginVersion("io.micronaut.library"), MicronautVersionHelper.getLatestMN4PluginVersion("io.micronaut.minimal.library"), MicronautVersionHelper.getLatestMN4PluginVersion("io.micronaut.test-resources"))));
     }
 
     @Test
     void updateMavenBuildPlugin() {
         rewriteRun(mavenProject("project",
-            //language=xml
-            pomXml("""
-                    <project>
-                        <groupId>com.mycompany.app</groupId>
-                        <artifactId>my-app</artifactId>
-                        <version>1</version>
-                        <parent>
-                            <groupId>io.micronaut</groupId>
-                            <artifactId>micronaut-parent</artifactId>
-                            <version>3.9.1</version>
-                        </parent>
-                        <build>
-                          <plugins>
-                              <plugin>
-                                  <groupId>io.micronaut.build</groupId>
-                                  <artifactId>micronaut-maven-plugin</artifactId>
-                              </plugin>
-                          </plugins>
-                        </build>
-                    </project>    
-                """, """
-                    <project>
-                        <groupId>com.mycompany.app</groupId>
-                        <artifactId>my-app</artifactId>
-                        <version>1</version>
-                        <parent>
-                            <groupId>io.micronaut.platform</groupId>
-                            <artifactId>micronaut-parent</artifactId>
-                            <version>4.0.0</version>
-                        </parent>
-                        <build>
-                          <plugins>
-                              <plugin>
-                                  <groupId>io.micronaut.maven</groupId>
-                                  <artifactId>micronaut-maven-plugin</artifactId>
-                              </plugin>
-                          </plugins>
-                        </build>
-                    </project>
-                """)));
+          //language=xml
+          pomXml("""
+                <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <parent>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-parent</artifactId>
+                        <version>3.9.1</version>
+                    </parent>
+                    <build>
+                      <plugins>
+                          <plugin>
+                              <groupId>io.micronaut.build</groupId>
+                              <artifactId>micronaut-maven-plugin</artifactId>
+                          </plugin>
+                      </plugins>
+                    </build>
+                </project>    
+            """, String.format("""
+                <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <parent>
+                        <groupId>io.micronaut.platform</groupId>
+                        <artifactId>micronaut-parent</artifactId>
+                        <version>%s</version>
+                    </parent>
+                    <build>
+                      <plugins>
+                          <plugin>
+                              <groupId>io.micronaut.maven</groupId>
+                              <artifactId>micronaut-maven-plugin</artifactId>
+                          </plugin>
+                      </plugins>
+                    </build>
+                </project>
+            """, latestMicronautVersion))));
     }
 }

--- a/src/test/java/org/openrewrite/java/micronaut/UpdateBuildToJava17Test.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpdateBuildToJava17Test.java
@@ -28,67 +28,58 @@ public class UpdateBuildToJava17Test implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(Environment.builder()
-          .scanRuntimeClasspath("org.openrewrite.java.migrate")
-          .build()
-          .activateRecipes("org.openrewrite.java.migrate.JavaVersion17"));
+        spec.recipe(Environment.builder().scanRuntimeClasspath("org.openrewrite.java.migrate").build().activateRecipes("org.openrewrite.java.migrate.JavaVersion17"));
     }
 
     @Test
     void updateGradleJavaVersion() {
         rewriteRun(mavenProject("project",
-                buildGradle(
-                        """
-                          version = "0.1.0-SNAPSHOT"
-                          group = "com.example"
-                          java {
-                              sourceCompatibility = JavaVersion.toVersion("1.8")
-                              targetCompatibility = JavaVersion.toVersion("1.8")
-                          }
-                          """,
-                        """
-                          version = "0.1.0-SNAPSHOT"
-                          group = "com.example"
-                          java {
-                              sourceCompatibility = JavaVersion.toVersion("17")
-                              targetCompatibility = JavaVersion.toVersion("17")
-                          }
-                          """
-                ))
-        );
+          //language=groovy
+          buildGradle("""
+            version = "0.1.0-SNAPSHOT"
+            group = "com.example"
+            java {
+                sourceCompatibility = JavaVersion.toVersion("1.8")
+                targetCompatibility = JavaVersion.toVersion("1.8")
+            }
+            """, """
+            version = "0.1.0-SNAPSHOT"
+            group = "com.example"
+            java {
+                sourceCompatibility = JavaVersion.toVersion("17")
+                targetCompatibility = JavaVersion.toVersion("17")
+            }
+            """)));
     }
 
     @Test
     void updateMavenJavaVersion() {
         rewriteRun(mavenProject("project",
-                pomXml(
-                        """
-                                    <project>
-                                        <modelVersion>4.0.0</modelVersion>
-                                        <groupId>com.mycompany.app</groupId>
-                                        <artifactId>my-app</artifactId>
-                                        <version>1</version>
-                                        <properties>
-                                            <packaging>jar</packaging>
-                                            <jdk.version>1.8</jdk.version>
-                                            <release.version>8</release.version>
-                                        </properties>
-                                    </project>
-                                """,
-                        """
-                                    <project>
-                                        <modelVersion>4.0.0</modelVersion>
-                                        <groupId>com.mycompany.app</groupId>
-                                        <artifactId>my-app</artifactId>
-                                        <version>1</version>
-                                        <properties>
-                                            <packaging>jar</packaging>
-                                            <jdk.version>17</jdk.version>
-                                            <release.version>17</release.version>
-                                        </properties>
-                                    </project>
-                          """
-                ))
-        );
+          //language=xml
+          pomXml("""
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <properties>
+                      <packaging>jar</packaging>
+                      <jdk.version>1.8</jdk.version>
+                      <release.version>8</release.version>
+                  </properties>
+              </project>
+          """, """
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>com.mycompany.app</groupId>
+                        <artifactId>my-app</artifactId>
+                        <version>1</version>
+                        <properties>
+                            <packaging>jar</packaging>
+                            <jdk.version>17</jdk.version>
+                            <release.version>17</release.version>
+                        </properties>
+                    </project>
+          """)));
     }
 }

--- a/src/test/java/org/openrewrite/java/micronaut/UpdateBuildToMicronaut4VersionTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpdateBuildToMicronaut4VersionTest.java
@@ -15,17 +15,15 @@
  */
 package org.openrewrite.java.micronaut;
 
-import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
-import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.maven.Assertions.pomXml;
 import static org.openrewrite.properties.Assertions.properties;
 
-public class UpdateBuildToMicronaut4VersionTest implements RewriteTest {
+public class UpdateBuildToMicronaut4VersionTest extends Micronaut4RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
@@ -33,50 +31,39 @@ public class UpdateBuildToMicronaut4VersionTest implements RewriteTest {
         spec.recipeFromResource("/META-INF/rewrite/micronaut3-to-4.yml", "org.openrewrite.java.micronaut.UpdateBuildToMicronaut4Version");
     }
 
-    @Language("properties")
-    private final String initialGradleProperties = """
-            micronautVersion=3.9.0
-        """;
-
-    @Language("properties")
-    private final String v4GradleProperties = """
-            micronautVersion=4.0.0
-        """;
-
-    @Language("xml")
-    private final String initialPomXml = """
-            <project>
-                <modelVersion>4.0.0</modelVersion>
-                <groupId>com.mycompany.app</groupId>
-                <artifactId>my-app</artifactId>
-                <version>1</version>
-                <properties>
-                    <micronaut.version>3.9.0</micronaut.version>
-                </properties>
-            </project>
-        """;
-
-    @Language("xml")
-    private final String v4PomXml = """
-            <project>
-                <modelVersion>4.0.0</modelVersion>
-                <groupId>com.mycompany.app</groupId>
-                <artifactId>my-app</artifactId>
-                <version>1</version>
-                <properties>
-                    <micronaut.version>4.0.0</micronaut.version>
-                </properties>
-            </project>
-        """;
-
     @Test
     public void updateGradleProperties() {
-        rewriteRun(properties(initialGradleProperties, v4GradleProperties,
-                s -> s.path("gradle.properties")));
+        rewriteRun(properties(String.format("""
+              micronautVersion=%s
+          """, MicronautVersionHelper.getLatestMN3Version()), String.format("""
+              micronautVersion=%s
+          """, latestMicronautVersion), s -> s.path("gradle.properties")));
     }
 
     @Test
     public void updatePomXmlProperties() {
-        rewriteRun(pomXml(initialPomXml, v4PomXml));
+        rewriteRun(
+          //language=xml
+          pomXml(String.format("""
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <properties>
+                        <micronaut.version>%s</micronaut.version>
+                    </properties>
+                </project>
+            """, MicronautVersionHelper.getLatestMN3Version()), String.format("""
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <properties>
+                        <micronaut.version>%s</micronaut.version>
+                    </properties>
+                </project>
+            """, latestMicronautVersion)));
     }
 }

--- a/src/test/java/org/openrewrite/java/micronaut/UpdateJakartaAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpdateJakartaAnnotationsTest.java
@@ -21,182 +21,164 @@ import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
-import org.openrewrite.test.RewriteTest;
-import org.openrewrite.test.SourceSpecs;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
-import static org.openrewrite.properties.Assertions.properties;
 
-public class UpdateJakartaAnnotationsTest implements RewriteTest {
+public class UpdateJakartaAnnotationsTest extends Micronaut4RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "jakarta.inject-api-2.*", "jakarta.annotation-api-2.*", "javax.annotation-api-1.3.2"));
-        spec.recipe(Environment.builder()
-          .scanRuntimeClasspath("org.openrewrite.java.micronaut")
-          .build()
-          .activateRecipes("org.openrewrite.java.micronaut.UpdateJakartaAnnotations"));
+        spec.recipe(Environment.builder().scanRuntimeClasspath("org.openrewrite.java.micronaut").build().activateRecipes("org.openrewrite.java.micronaut.UpdateJakartaAnnotations"));
     }
 
     @Language("java")
     private final String annotatedJavaxClass = """
-            import javax.annotation.PostConstruct;
-            import jakarta.inject.Singleton;
-            
-            @Singleton
-            public class FooService {
-            
-                @PostConstruct
-                public void init() {
-                
-                }
-            }
-        """;
+          import javax.annotation.PostConstruct;
+          import jakarta.inject.Singleton;
+          
+          @Singleton
+          public class FooService {
+          
+              @PostConstruct
+              public void init() {
+              
+              }
+          }
+      """;
 
     @Language("java")
     private final String annotatedJakartaClass = """
-            import jakarta.annotation.PostConstruct;
-            import jakarta.inject.Singleton;
-            
-            @Singleton
-            public class FooService {
-            
-                @PostConstruct
-                public void init() {
-                
-                }
-            }
-        """;
-
-    private final SourceSpecs gradleProperties = properties("micronautVersion=4.0.0", s -> s.path("gradle.properties"));
-
-    @Language("groovy")
-    private final String buildGradleWithDependency = """
-            plugins {
-                id("io.micronaut.application") version "4.0.0"
-            }
-            
-            repositories {
-                mavenCentral()
-            }
-            
-            dependencies {
-                annotationProcessor("io.micronaut:micronaut-http-validation")
-                implementation("io.micronaut:micronaut-http-client")
-                implementation("io.micronaut:micronaut-jackson-databind")
-                implementation "jakarta.annotation:jakarta.annotation-api:2.1.1"
-                runtimeOnly("ch.qos.logback:logback-classic")
-            }
-        """;
-
-    @Language("groovy")
-    private final String buildGradleWithoutDependency = """
-            plugins {
-                id("io.micronaut.application") version "4.0.0"
-            }
-            
-            repositories {
-                mavenCentral()
-            }
-            
-            dependencies {
-                annotationProcessor("io.micronaut:micronaut-http-validation")
-                implementation("io.micronaut:micronaut-http-client")
-                implementation("io.micronaut:micronaut-jackson-databind")
-                runtimeOnly("ch.qos.logback:logback-classic")
-            }
-        """;
-
-    @Language("xml")
-    private final String pomWithDependency = """
-            <project>
-                <groupId>com.mycompany.app</groupId>
-                <artifactId>my-app</artifactId>
-                <version>1</version>
-                <parent>
-                    <groupId>io.micronaut.platform</groupId>
-                    <artifactId>micronaut-parent</artifactId>
-                    <version>4.0.0</version>
-                </parent>
-                <dependencies>
-                    <dependency>
-                        <groupId>io.micronaut</groupId>
-                        <artifactId>micronaut-http-client</artifactId>
-                        <scope>compile</scope>
-                    </dependency>
-                    <dependency>
-                        <groupId>io.micronaut</groupId>
-                        <artifactId>micronaut-http-server-netty</artifactId>
-                        <scope>compile</scope>
-                    </dependency>
-                    <dependency>
-                        <groupId>io.micronaut</groupId>
-                        <artifactId>micronaut-jackson-databind</artifactId>
-                        <scope>compile</scope>
-                    </dependency>
-                    <dependency>
-                        <groupId>jakarta.annotation</groupId>
-                        <artifactId>jakarta.annotation-api</artifactId>
-                        <scope>compile</scope>
-                    </dependency>
-                    <dependency>
-                        <groupId>ch.qos.logback</groupId>
-                        <artifactId>logback-classic</artifactId>
-                        <scope>runtime</scope>
-                    </dependency>
-                </dependencies>
-            </project>
-        """;
-
-    @Language("xml")
-    private final String pomWithoutDependency = """
-            <project>
-                <groupId>com.mycompany.app</groupId>
-                <artifactId>my-app</artifactId>
-                <version>1</version>
-                <parent>
-                    <groupId>io.micronaut.platform</groupId>
-                    <artifactId>micronaut-parent</artifactId>
-                    <version>4.0.0</version>
-                </parent>
-                <dependencies>
-                    <dependency>
-                        <groupId>io.micronaut</groupId>
-                        <artifactId>micronaut-http-client</artifactId>
-                        <scope>compile</scope>
-                    </dependency>
-                    <dependency>
-                        <groupId>io.micronaut</groupId>
-                        <artifactId>micronaut-http-server-netty</artifactId>
-                        <scope>compile</scope>
-                    </dependency>
-                    <dependency>
-                        <groupId>io.micronaut</groupId>
-                        <artifactId>micronaut-jackson-databind</artifactId>
-                        <scope>compile</scope>
-                    </dependency>
-                    <dependency>
-                        <groupId>ch.qos.logback</groupId>
-                        <artifactId>logback-classic</artifactId>
-                        <scope>runtime</scope>
-                    </dependency>
-                </dependencies>
-            </project>
-        """;
+          import jakarta.annotation.PostConstruct;
+          import jakarta.inject.Singleton;
+          
+          @Singleton
+          public class FooService {
+          
+              @PostConstruct
+              public void init() {
+              
+              }
+          }
+      """;
 
     @Test
     void updateJavaCodeAndRemoveGradleDependency() {
-        rewriteRun(spec -> spec.beforeRecipe(withToolingApi()), mavenProject("project", srcMainJava(java(annotatedJavaxClass, annotatedJakartaClass)),
-                gradleProperties, buildGradle(buildGradleWithDependency, buildGradleWithoutDependency)));
+        rewriteRun(spec -> spec.beforeRecipe(withToolingApi()), mavenProject("project", srcMainJava(java(annotatedJavaxClass, annotatedJakartaClass)), getGradleProperties(),
+          //language=groovy
+          buildGradle(String.format("""
+                plugins {
+                    id("io.micronaut.application") version "%s"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
+                dependencies {
+                    annotationProcessor("io.micronaut:micronaut-http-validation")
+                    implementation("io.micronaut:micronaut-http-client")
+                    implementation("io.micronaut:micronaut-jackson-databind")
+                    implementation "jakarta.annotation:jakarta.annotation-api:2.1.1"
+                    runtimeOnly("ch.qos.logback:logback-classic")
+                }
+            """, latestApplicationPluginVersion), String.format("""
+                plugins {
+                    id("io.micronaut.application") version "%s"
+                }
+                
+                repositories {
+                    mavenCentral()
+                }
+                
+                dependencies {
+                    annotationProcessor("io.micronaut:micronaut-http-validation")
+                    implementation("io.micronaut:micronaut-http-client")
+                    implementation("io.micronaut:micronaut-jackson-databind")
+                    runtimeOnly("ch.qos.logback:logback-classic")
+                }
+            """, latestApplicationPluginVersion))));
 
     }
 
     @Test
     void updateJavaCodeAndRemoveMavenDependency() {
         rewriteRun(mavenProject("project", srcMainJava(java(annotatedJavaxClass, annotatedJakartaClass)),
-                pomXml(pomWithDependency, pomWithoutDependency)));
+          //language=xml
+          pomXml(String.format("""
+                <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <parent>
+                        <groupId>io.micronaut.platform</groupId>
+                        <artifactId>micronaut-parent</artifactId>
+                        <version>%s</version>
+                    </parent>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.micronaut</groupId>
+                            <artifactId>micronaut-http-client</artifactId>
+                            <scope>compile</scope>
+                        </dependency>
+                        <dependency>
+                            <groupId>io.micronaut</groupId>
+                            <artifactId>micronaut-http-server-netty</artifactId>
+                            <scope>compile</scope>
+                        </dependency>
+                        <dependency>
+                            <groupId>io.micronaut</groupId>
+                            <artifactId>micronaut-jackson-databind</artifactId>
+                            <scope>compile</scope>
+                        </dependency>
+                        <dependency>
+                            <groupId>jakarta.annotation</groupId>
+                            <artifactId>jakarta.annotation-api</artifactId>
+                            <scope>compile</scope>
+                        </dependency>
+                        <dependency>
+                            <groupId>ch.qos.logback</groupId>
+                            <artifactId>logback-classic</artifactId>
+                            <scope>runtime</scope>
+                        </dependency>
+                    </dependencies>
+                </project>
+            """, latestMicronautVersion), String.format("""
+                <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <parent>
+                        <groupId>io.micronaut.platform</groupId>
+                        <artifactId>micronaut-parent</artifactId>
+                        <version>%s</version>
+                    </parent>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.micronaut</groupId>
+                            <artifactId>micronaut-http-client</artifactId>
+                            <scope>compile</scope>
+                        </dependency>
+                        <dependency>
+                            <groupId>io.micronaut</groupId>
+                            <artifactId>micronaut-http-server-netty</artifactId>
+                            <scope>compile</scope>
+                        </dependency>
+                        <dependency>
+                            <groupId>io.micronaut</groupId>
+                            <artifactId>micronaut-jackson-databind</artifactId>
+                            <scope>compile</scope>
+                        </dependency>
+                        <dependency>
+                            <groupId>ch.qos.logback</groupId>
+                            <artifactId>logback-classic</artifactId>
+                            <scope>runtime</scope>
+                        </dependency>
+                    </dependencies>
+                </project>
+            """, latestMicronautVersion))));
     }
 }

--- a/src/test/java/org/openrewrite/java/micronaut/UpdateMicronautDataTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpdateMicronautDataTest.java
@@ -22,26 +22,16 @@ import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
-import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
 
-public class UpdateMicronautDataTest implements RewriteTest {
+public class UpdateMicronautDataTest extends Micronaut4RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec
-          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
-            "javax.transaction-api-1.*", "jakarta.transaction-api-2.*", "micronaut-data-jdbc-3.*", "micronaut-data-jdbc-4.*",
-            "micronaut-data-model-4.*", "micronaut-data-tx-3.*", "micronaut-data-tx-4.*"))
-          .recipes(Environment.builder()
-            .scanRuntimeClasspath("org.openrewrite.java.micronaut")
-            .build()
-            .activateRecipes(
-              "org.openrewrite.java.micronaut.UpdateMicronautPlatformBom",
-              "org.openrewrite.java.micronaut.UpdateMicronautData"));
+        spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "javax.transaction-api-1.*", "jakarta.transaction-api-2.*", "micronaut-data-jdbc-3.*", "micronaut-data-jdbc-4.*", "micronaut-data-model-4.*", "micronaut-data-tx-3.*", "micronaut-data-tx-4.*")).recipes(Environment.builder().scanRuntimeClasspath("org.openrewrite.java.micronaut").build().activateRecipes("org.openrewrite.java.micronaut.UpdateMicronautPlatformBom", "org.openrewrite.java.micronaut.UpdateMicronautData"));
     }
 
     @Language("java")
@@ -98,7 +88,7 @@ public class UpdateMicronautDataTest implements RewriteTest {
     void updateJavaCodeAndUnmodifiedMavenDependencies() {
         rewriteRun(mavenProject("project", srcMainJava(java(annotatedJavaxTxRepository, annotatedJakartaTxRepository)),
           //language=xml
-          pomXml("""
+          pomXml(String.format("""
             <project>
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
@@ -106,7 +96,7 @@ public class UpdateMicronautDataTest implements RewriteTest {
                 <parent>
                     <groupId>io.micronaut.platform</groupId>
                     <artifactId>micronaut-parent</artifactId>
-                    <version>4.0.0</version>
+                    <version>%s</version>
                 </parent>
                 <dependencies>
                     <dependency>
@@ -124,7 +114,7 @@ public class UpdateMicronautDataTest implements RewriteTest {
                     </plugins>
                 </build>
             </project>
-            """)));
+            """, latestMicronautVersion))));
     }
 
     @Test

--- a/src/test/java/org/openrewrite/java/micronaut/UpdateMicronautSessionTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpdateMicronautSessionTest.java
@@ -15,83 +15,73 @@
  */
 package org.openrewrite.java.micronaut;
 
-import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RecipeSpec;
-import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 
-public class UpdateMicronautSessionTest implements RewriteTest {
+public class UpdateMicronautSessionTest extends Micronaut4RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipeFromResource("/META-INF/rewrite/micronaut3-to-4.yml", "org.openrewrite.java.micronaut.UpdateMicronautPlatformBom", "org.openrewrite.java.micronaut.UpdateMicronautSession");
     }
 
-    @Language("groovy")
-    private final String buildGradleInitial = """
-            dependencies {
-                implementation("io.micronaut:micronaut-session")
-            }
-        """;
-
-    @Language("groovy")
-    private final String buildGradleExpected = """
-            dependencies {
-                implementation("io.micronaut.session:micronaut-session")
-            }
-        """;
-
-    @Language("xml")
-    private final String pomInitial = """
-            <project>
-                <groupId>com.mycompany.app</groupId>
-                <artifactId>my-app</artifactId>
-                <version>1</version>
-                <parent>
-                    <groupId>io.micronaut</groupId>
-                    <artifactId>micronaut-parent</artifactId>
-                    <version>3.9.1</version>
-                </parent>
-                <dependencies>
-                    <dependency>
-                        <groupId>io.micronaut</groupId>
-                        <artifactId>micronaut-session</artifactId>
-                    </dependency>
-                </dependencies>
-            </project>
-        """;
-
-    @Language("xml")
-    private final String pomExpected = """
-            <project>
-                <groupId>com.mycompany.app</groupId>
-                <artifactId>my-app</artifactId>
-                <version>1</version>
-                <parent>
-                    <groupId>io.micronaut.platform</groupId>
-                    <artifactId>micronaut-parent</artifactId>
-                    <version>4.0.0</version>
-                </parent>
-                <dependencies>
-                    <dependency>
-                        <groupId>io.micronaut.session</groupId>
-                        <artifactId>micronaut-session</artifactId>
-                    </dependency>
-                </dependencies>
-            </project>
-        """;
-
     @Test
     void updateGradleDependencies() {
-        rewriteRun(mavenProject("project", buildGradle(buildGradleInitial, buildGradleExpected)));
+        rewriteRun(mavenProject("project",
+          //language=groovy
+          buildGradle("""
+                dependencies {
+                    implementation("io.micronaut:micronaut-session")
+                }
+            """, """
+                dependencies {
+                    implementation("io.micronaut.session:micronaut-session")
+                }
+            """)));
     }
 
     @Test
     void updateMavenDependencies() {
-        rewriteRun(mavenProject("project", pomXml(pomInitial, pomExpected)));
+        rewriteRun(mavenProject("project",
+          //language=xml
+          pomXml(String.format("""
+                <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <parent>
+                        <groupId>io.micronaut</groupId>
+                        <artifactId>micronaut-parent</artifactId>
+                        <version>%s</version>
+                    </parent>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.micronaut</groupId>
+                            <artifactId>micronaut-session</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+            """, MicronautVersionHelper.getLatestMN3Version()), String.format("""
+                <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <parent>
+                        <groupId>io.micronaut.platform</groupId>
+                        <artifactId>micronaut-parent</artifactId>
+                        <version>%s</version>
+                    </parent>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.micronaut.session</groupId>
+                            <artifactId>micronaut-session</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+            """, latestMicronautVersion))));
     }
 }

--- a/src/test/java/org/openrewrite/java/micronaut/UpgradeMicronautGradlePropertiesVersionTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpgradeMicronautGradlePropertiesVersionTest.java
@@ -18,7 +18,6 @@ package org.openrewrite.java.micronaut;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.openrewrite.DocumentExample;
-import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import java.io.IOException;
@@ -29,30 +28,43 @@ import static org.openrewrite.properties.Assertions.properties;
 @SuppressWarnings("UnusedProperty")
 class UpgradeMicronautGradlePropertiesVersionTest implements RewriteTest {
 
-    @Override
-    public void defaults(RecipeSpec spec) {
-        spec.recipe(new UpgradeMicronautGradlePropertiesVersion("~2.1"));
-    }
-
     @DocumentExample
     @Test
-    void changeValue(@TempDir Path tempDir) throws IOException {
-        rewriteRun(
+    void upgradeMicronaut2(@TempDir Path tempDir) throws IOException {
+        String latestMicronautVersion = MicronautVersionHelper.getLatestMN2Version();
+
+        rewriteRun(spec -> spec.recipe(new UpgradeMicronautGradlePropertiesVersion("2.x")),
           properties(
             "micronautVersion=2.0.3",
-            "micronautVersion=2.1.4",
+            String.format("micronautVersion=%s", latestMicronautVersion),
             source -> source.path("gradle.properties")
           )
         );
     }
 
     @Test
+    void upgradeToMicronaut3() {
+        String latestMicronautVersion = MicronautVersionHelper.getLatestMN3Version();
+
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeMicronautGradlePropertiesVersion("3.x")),
+          properties(
+            "micronautVersion=2.0.3",
+            String.format("micronautVersion=%s", latestMicronautVersion),
+            s -> s.path("gradle.properties")
+          )
+        );
+    }
+
+    @Test
     void upgradeToMicronaut4() {
+        String latestMicronautVersion = MicronautVersionHelper.getLatestMN4Version();
+
         rewriteRun(
           spec -> spec.recipe(new UpgradeMicronautGradlePropertiesVersion("4.x")),
           properties(
             "micronautVersion=3.9.0",
-            "micronautVersion=4.0.0",
+            String.format("micronautVersion=%s", latestMicronautVersion),
             s -> s.path("gradle.properties")
           )
         );

--- a/src/test/java/org/openrewrite/java/micronaut/UpgradeMicronautMavenPropertyVersionTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpgradeMicronautMavenPropertyVersionTest.java
@@ -17,21 +17,18 @@ package org.openrewrite.java.micronaut;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class UpgradeMicronautMavenPropertyVersionTest implements RewriteTest {
-    @Override
-    public void defaults(RecipeSpec spec) {
-        spec.recipe(new UpgradeMicronautMavenPropertyVersion("~2.1"));
-    }
 
     @DocumentExample
     @Test
     void changeMavenMicronautVersion() {
-        rewriteRun(
+        String latestMicronautVersion = MicronautVersionHelper.getLatestMN2Version();
+
+        rewriteRun(spec -> spec.recipe(new UpgradeMicronautMavenPropertyVersion("2.x")),
           pomXml("""
                   <project>
                       <modelVersion>4.0.0</modelVersion>
@@ -43,22 +40,54 @@ class UpgradeMicronautMavenPropertyVersionTest implements RewriteTest {
                       </properties>
                   </project>
               """,
-            """
+            String.format("""
                   <project>
                       <modelVersion>4.0.0</modelVersion>
                       <groupId>com.mycompany.app</groupId>
                       <artifactId>my-app</artifactId>
                       <version>1</version>
                       <properties>
-                          <micronaut.version>2.1.4</micronaut.version>
+                          <micronaut.version>%s</micronaut.version>
                       </properties>
                   </project>
-              """)
+              """, latestMicronautVersion))
+        );
+    }
+
+    @Test
+    void changeMavenMicronautVersion3() {
+        String latestMicronautVersion = MicronautVersionHelper.getLatestMN3Version();
+
+        rewriteRun(spec -> spec.recipe(new UpgradeMicronautMavenPropertyVersion("3.x")),
+          pomXml("""
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.mycompany.app</groupId>
+                      <artifactId>my-app</artifactId>
+                      <version>1</version>
+                      <properties>
+                          <micronaut.version>2.0.3</micronaut.version>
+                      </properties>
+                  </project>
+              """,
+            String.format("""
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.mycompany.app</groupId>
+                      <artifactId>my-app</artifactId>
+                      <version>1</version>
+                      <properties>
+                          <micronaut.version>%s</micronaut.version>
+                      </properties>
+                  </project>
+              """, latestMicronautVersion))
         );
     }
 
     @Test
     void changeMavenMicronautVersion4() {
+        String latestMicronautVersion = MicronautVersionHelper.getLatestMN4Version();
+
         rewriteRun(
           spec -> spec.recipe(new UpgradeMicronautMavenPropertyVersion("4.x")),
           pomXml("""
@@ -72,17 +101,17 @@ class UpgradeMicronautMavenPropertyVersionTest implements RewriteTest {
                       </properties>
                   </project>
               """,
-            """
+            String.format("""
                   <project>
                       <modelVersion>4.0.0</modelVersion>
                       <groupId>com.mycompany.app</groupId>
                       <artifactId>my-app</artifactId>
                       <version>1</version>
                       <properties>
-                          <micronaut.version>4.0.0</micronaut.version>
+                          <micronaut.version>%s</micronaut.version>
                       </properties>
                   </project>
-              """)
+              """, latestMicronautVersion))
         );
     }
 }


### PR DESCRIPTION
## What's changed?
Refactor the tests to dynamically resolve and match the latest version(s) for Micronaut Framework. This should allow 
us to not have to update version numbers in the tests everytime a new version of Micronaut Framework is release, while
also still ensuring that we are always testing against the latest version.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
