### PR TITLE
Remove Micronaut Data version from pom.xml

### DIFF
--- a/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
+++ b/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
@@ -325,7 +325,13 @@ name: org.openrewrite.java.micronaut.UpdateMicronautData
 displayName: Update the Micronaut Data library
 description: This recipe will make the necessary updates for using Micronaut Data with Micronaut Framework 4.
 recipeList:
-  - org.openrewrite.java.migrate.jakarta.JavaxTransactionMigrationToJakartaTransaction
+  - org.openrewrite.xml.RemoveXmlTag:
+      xPath: /project/properties/micronaut.data.version
+      fileMatcher: '**/pom.xml'
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: javax.transaction
+      newPackageName: jakarta.transaction
+      recursive: true
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: io.micronaut.data.jdbc.annotation.ColumnTransformer
       newFullyQualifiedTypeName: io.micronaut.data.annotation.sql.ColumnTransformer

--- a/src/test/java/org/openrewrite/java/micronaut/UpdateMicronautDataTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpdateMicronautDataTest.java
@@ -98,6 +98,9 @@ public class UpdateMicronautDataTest extends Micronaut4RewriteTest {
                     <artifactId>micronaut-parent</artifactId>
                     <version>%s</version>
                 </parent>
+                <properties>
+                    <micronaut.version>%1$s</micronaut.version>
+                </properties>
                 <dependencies>
                     <dependency>
                         <groupId>io.micronaut.data</groupId>
@@ -105,16 +108,59 @@ public class UpdateMicronautDataTest extends Micronaut4RewriteTest {
                         <scope>compile</scope>
                     </dependency>
                 </dependencies>
-                <build>
-                    <plugins>
-                        <plugin>
-                            <groupId>io.micronaut.build</groupId>
-                            <artifactId>micronaut-maven-plugin</artifactId>
-                        </plugin>
-                    </plugins>
-                </build>
             </project>
             """.formatted(latestMicronautVersion))));
+    }
+
+    @Test
+    void updateJavaCodeAndMavenDataVersion() {
+        rewriteRun(mavenProject("project", srcMainJava(java(annotatedJavaxTxRepository, annotatedJakartaTxRepository)),
+          //language=xml
+          pomXml("""
+              <project>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <parent>
+                      <groupId>io.micronaut.platform</groupId>
+                      <artifactId>micronaut-parent</artifactId>
+                      <version>%1$s</version>
+                  </parent>
+                  <properties>
+                      <micronaut.version>%1$s</micronaut.version>
+                      <micronaut.data.version>%2$s</micronaut.data.version>
+                  </properties>
+                  <dependencies>
+                      <dependency>
+                          <groupId>io.micronaut.data</groupId>
+                          <artifactId>micronaut-data-jdbc</artifactId>
+                          <scope>compile</scope>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """.formatted(latestMicronautVersion, "3.10.0"),
+            """
+              <project>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <parent>
+                      <groupId>io.micronaut.platform</groupId>
+                      <artifactId>micronaut-parent</artifactId>
+                      <version>%1$s</version>
+                  </parent>
+                  <properties>
+                      <micronaut.version>%1$s</micronaut.version>
+                  </properties>
+                  <dependencies>
+                      <dependency>
+                          <groupId>io.micronaut.data</groupId>
+                          <artifactId>micronaut-data-jdbc</artifactId>
+                          <scope>compile</scope>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """.formatted(latestMicronautVersion))));
     }
 
     @Test


### PR DESCRIPTION
## What's changed?
The `UpdateMicronautData` recipe has been modified to remove the `micronaut.data.version` property from pom.xml 
as it is not needed with Micronaut Framework 4.

Also had to revert from using the OOTB javax-to-jakarta persistence upgrade recipe as it was erroneously adding the 
jakarta transaction API dependency despite it already being included transitively.

This will resolve issue #78

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
