### PR TITLE
Add Test Resources Client dependency to pom.xml if needed.

### DIFF
--- a/src/main/java/org/openrewrite/java/micronaut/AddTestResourcesClientDependencyIfNeeded.java
+++ b/src/main/java/org/openrewrite/java/micronaut/AddTestResourcesClientDependencyIfNeeded.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.micronaut;
+
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.maven.AddDependency;
+import org.openrewrite.maven.MavenIsoVisitor;
+import org.openrewrite.maven.search.FindProperties;
+import org.openrewrite.xml.tree.Xml;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class AddTestResourcesClientDependencyIfNeeded extends ScanningRecipe<AddTestResourcesClientDependencyIfNeeded.Scanned> {
+
+    private final List<Recipe> recipeList = new ArrayList<>();
+
+    static class Scanned {
+        boolean isTestResourcesEnabled = false;
+    }
+
+    public AddTestResourcesClientDependencyIfNeeded() {
+        recipeList.add(new AddDependency("io.micronaut.testresources", "micronaut-test-resources-client", "LATEST",
+                null, "provided", null, "io.micronaut.runtime.Micronaut", null, null, null, null, null));
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Add Test Resources Client dependency if needed";
+    }
+
+    @Override
+    public String getDescription() {
+        return "This recipe adds the Test Resources Client dependency to pom.xml if test.resources.client.enabled property is true.";
+    }
+
+    @Override
+    public List<Recipe> getRecipeList() {
+        return this.recipeList;
+    }
+
+    @Override
+    public Scanned getInitialValue(ExecutionContext ctx) {
+        return new Scanned();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Scanned acc) {
+        return new MavenIsoVisitor<ExecutionContext>() {
+            @Override
+            public Xml.Document visitDocument(Xml.Document document, ExecutionContext executionContext) {
+                Xml.Document maven = super.visitDocument(document, executionContext);
+                Optional<Xml.Tag> testResourcesProp = FindProperties.find(document, "micronaut.test.resources.enabled").stream().findFirst();
+                if ("true".equals(testResourcesProp.flatMap(Xml.Tag::getValue).orElse("false"))) {
+                    acc.isTestResourcesEnabled = true;
+                }
+                return maven;
+            }
+        };
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(Scanned acc) {
+        return Preconditions.check(!acc.isTestResourcesEnabled, new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext executionContext) {
+                if (!recipeList.isEmpty()) {
+                    recipeList.clear();
+                }
+                return super.visit(tree, executionContext);
+            }
+        });
+    }
+}

--- a/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
+++ b/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
@@ -41,6 +41,7 @@ recipeList:
   - org.openrewrite.java.micronaut.RemoveUnnecessaryDependencies
   - org.openrewrite.java.micronaut.AddHttpRequestTypeParameter
   - org.openrewrite.java.micronaut.UpdateMavenAnnotationProcessors
+  - org.openrewrite.java.micronaut.AddTestResourcesClientDependencyIfNeeded
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.micronaut.UpdateBuildToMicronaut4Version

--- a/src/test/java/org/openrewrite/java/micronaut/AddTestResourcesClientDependencyIfNeededTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/AddTestResourcesClientDependencyIfNeededTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.micronaut;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+
+import static org.openrewrite.java.Assertions.*;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+public class AddTestResourcesClientDependencyIfNeededTest extends Micronaut4RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+            "micronaut-context-4.*"))
+          .recipe(new AddTestResourcesClientDependencyIfNeeded());
+    }
+
+    @Language("java")
+    private final String micronautApplication = """
+            import io.micronaut.runtime.Micronaut;
+            
+            public class Application {
+            
+                public static void main(String[] args) {
+                    Micronaut.run(Application.class, args);
+                }
+            }
+      """;
+
+    @Test
+    void addTestResourcesClientDependencyForMaven() {
+        rewriteRun(mavenProject("project", srcMainJava(java(micronautApplication)),
+          //language=xml
+          pomXml("""
+              <project>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <parent>
+                      <groupId>io.micronaut.platform</groupId>
+                      <artifactId>micronaut-parent</artifactId>
+                      <version>%1$s</version>
+                  </parent>
+                  <properties>
+                      <micronaut.version>%1$s</micronaut.version>
+                      <micronaut.test.resources.enabled>true</micronaut.test.resources.enabled>
+                  </properties>
+              </project>
+              """.formatted(latestMicronautVersion),
+            """
+              <project>
+                  <groupId>com.mycompany.app</groupId>
+                  <artifactId>my-app</artifactId>
+                  <version>1</version>
+                  <parent>
+                      <groupId>io.micronaut.platform</groupId>
+                      <artifactId>micronaut-parent</artifactId>
+                      <version>%1$s</version>
+                  </parent>
+                  <properties>
+                      <micronaut.version>%1$s</micronaut.version>
+                      <micronaut.test.resources.enabled>true</micronaut.test.resources.enabled>
+                  </properties>
+                  <dependencies>
+                      <dependency>
+                          <groupId>io.micronaut.testresources</groupId>
+                          <artifactId>micronaut-test-resources-client</artifactId>
+                          <scope>provided</scope>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """.formatted(latestMicronautVersion))));
+    }
+
+    @Test
+    void noDependencyAddedForPropertyFalse() {
+        rewriteRun(mavenProject("project", srcMainJava(java(micronautApplication)),
+          //language=xml
+          pomXml("""
+            <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <parent>
+                    <groupId>io.micronaut.platform</groupId>
+                    <artifactId>micronaut-parent</artifactId>
+                    <version>%1$s</version>
+                </parent>
+                <properties>
+                    <micronaut.version>%1$s</micronaut.version>
+                    <micronaut.test.resources.enabled>false</micronaut.test.resources.enabled>
+                </properties>
+            </project>
+            """.formatted(latestMicronautVersion))));
+    }
+
+    @Test
+    void noDependencyAddedForPropertyNotSet() {
+        rewriteRun(mavenProject("project", srcMainJava(java(micronautApplication)),
+          //language=xml
+          pomXml("""
+            <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <parent>
+                    <groupId>io.micronaut.platform</groupId>
+                    <artifactId>micronaut-parent</artifactId>
+                    <version>%1$s</version>
+                </parent>
+                <properties>
+                    <micronaut.version>%1$s</micronaut.version>
+                </properties>
+            </project>
+            """.formatted(latestMicronautVersion))));
+    }
+
+}


### PR DESCRIPTION
## What's changed?
Added a new `AddTestResourcesClientDependencyIfNeeded` recipe that checks for the `micronaut.test.resources.enabled` 
property set to `true` in pom.xml. If the property is configured, the appropriate micronaut-test-resources-client 
dependency is added.

This will resolve issue #79

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files