### PR TITLE
Correctly apply version when executed by Maven plugin.

### DIFF
--- a/src/main/java/org/openrewrite/java/micronaut/AddAnnotationProcessorPath.java
+++ b/src/main/java/org/openrewrite/java/micronaut/AddAnnotationProcessorPath.java
@@ -28,7 +28,6 @@ import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.tree.Xml;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
@@ -166,18 +165,9 @@ public class AddAnnotationProcessorPath extends ScanningRecipe<AddAnnotationProc
                 return "";
             }
             return "<exclusions>\n" +
-                    exclusions.stream().map(exclusion -> {
-                        StringBuilder exclusionContent = new StringBuilder("<exclusion>\n");
-                        String[] exclusionParts = exclusion.split(":");
-                        if (exclusionParts.length != 2) {
-                            throw new IllegalStateException("Expected an exclusion in the form of groupId:artifactId but was '" + exclusion + "'");
-                        }
-                        exclusionContent.append("<groupId>").append(exclusionParts[0]).append("</groupId>\n")
-                                .append("<artifactId>").append(exclusionParts[1]).append("</artifactId>\n")
-                                .append("</exclusion>\n");
-                        return exclusionContent.toString();
-                    }).collect(Collectors.joining()) +
+                    MavenExclusions.buildContent(exclusions) +
                     "</exclusions>";
         }
     }
+
 }

--- a/src/main/java/org/openrewrite/java/micronaut/MavenExclusions.java
+++ b/src/main/java/org/openrewrite/java/micronaut/MavenExclusions.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.micronaut;
+
+import org.openrewrite.internal.lang.Nullable;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MavenExclusions {
+    static String buildContent(@Nullable List<String> exclusions) {
+        if (exclusions == null) {
+            return "";
+        }
+
+        return exclusions.stream().map(exclusion -> {
+            StringBuilder exclusionContent = new StringBuilder("<exclusion>\n");
+            String[] exclusionParts = exclusion.split(":");
+            if (exclusionParts.length != 2) {
+                throw new IllegalStateException("Expected an exclusion in the form of groupId:artifactId but was '" + exclusion + "'");
+            }
+            exclusionContent.append("<groupId>").append(exclusionParts[0]).append("</groupId>\n")
+                    .append("<artifactId>").append(exclusionParts[1]).append("</artifactId>\n")
+                    .append("</exclusion>\n");
+            return exclusionContent.toString();
+        }).collect(Collectors.joining());
+    }
+}

--- a/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
+++ b/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
@@ -384,12 +384,12 @@ recipeList:
   - org.openrewrite.java.micronaut.ChangeAnnotationProcessorPath:
       oldGroupId: io.micronaut
       oldArtifactId: micronaut-inject-java
-      newVersion: ${micronaut.core.version}
+      newVersion: micronaut.core.version
   - org.openrewrite.java.micronaut.ChangeAnnotationProcessorPath:
       oldGroupId: io.micronaut
       oldArtifactId: micronaut-http-validation
-      newVersion: ${micronaut.core.version}
+      newVersion: micronaut.core.version
   - org.openrewrite.java.micronaut.ChangeAnnotationProcessorPath:
       oldGroupId: io.micronaut
       oldArtifactId: micronaut-graal
-      newVersion: ${micronaut.core.version}
+      newVersion: micronaut.core.version

--- a/src/test/java/org/openrewrite/java/micronaut/UpdateMavenAnnotationProcessorsTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpdateMavenAnnotationProcessorsTest.java
@@ -41,10 +41,20 @@ public class UpdateMavenAnnotationProcessorsTest extends Micronaut4RewriteTest {
                 <artifactId>my-app</artifactId>
                 <version>1</version>
                 <parent>
-                    <groupId>io.micronaut.platform</groupId>
+                    <groupId>io.micronaut</groupId>
                     <artifactId>micronaut-parent</artifactId>
                     <version>%s</version>
                 </parent>
+                <properties>
+                    <packaging>jar</packaging>
+                    <jdk.version>11</jdk.version>
+                    <release.version>11</release.version>
+                    <micronaut.version>3.9.2</micronaut.version>
+                    <micronaut.test.resources.enabled>true</micronaut.test.resources.enabled>
+                    <micronaut.data.version>3.10.0</micronaut.data.version>
+                    <micronaut.runtime>netty</micronaut.runtime>
+                    <exec.mainClass>example.micronaut.Application</exec.mainClass>
+                </properties>
                 <dependencies>
                     <dependency>
                         <groupId>io.micronaut</groupId>
@@ -103,16 +113,26 @@ public class UpdateMavenAnnotationProcessorsTest extends Micronaut4RewriteTest {
                     </plugins>
                 </build>
             </project>
-            """.formatted(latestMicronautVersion), """
+            """.formatted(MicronautRewriteTestVersions.getLatestMN3Version()), """
             <project>
                 <groupId>com.mycompany.app</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
                 <parent>
-                    <groupId>io.micronaut.platform</groupId>
+                    <groupId>io.micronaut</groupId>
                     <artifactId>micronaut-parent</artifactId>
                     <version>%s</version>
                 </parent>
+                <properties>
+                    <packaging>jar</packaging>
+                    <jdk.version>11</jdk.version>
+                    <release.version>11</release.version>
+                    <micronaut.version>3.9.2</micronaut.version>
+                    <micronaut.test.resources.enabled>true</micronaut.test.resources.enabled>
+                    <micronaut.data.version>3.10.0</micronaut.data.version>
+                    <micronaut.runtime>netty</micronaut.runtime>
+                    <exec.mainClass>example.micronaut.Application</exec.mainClass>
+                </properties>
                 <dependencies>
                     <dependency>
                         <groupId>io.micronaut</groupId>
@@ -171,7 +191,7 @@ public class UpdateMavenAnnotationProcessorsTest extends Micronaut4RewriteTest {
                     </plugins>
                 </build>
             </project>
-            """.formatted(latestMicronautVersion)));
+            """.formatted(MicronautRewriteTestVersions.getLatestMN3Version())));
     }
 
     @Test


### PR DESCRIPTION
## What's changed?
The `UpdateMavenAnnotationProcessors` recipe has been updated to correctly apply `${micronaut.core.version}` to the 
annotation processor paths in pom.xml when invoked by the OpenRewrite Maven plugin.

Added some additional checking to prevent repeated edits to the XML tags.

Also did a little cleanup to extract some code shared by `AddAnnotationProcessorPath` and `ChangeAnnotationProcessorPath`.

## What's your motivation?
The Maven plugin seemed to be trying to resolve the specified `${micronaut.core.version}` value into an actual 
version number before passing the value to the `ChangeAnnotationProcessorPath` recipe.

## Anything in particular you'd like reviewers to focus on?
Is there maybe a simpler way to do this? Is there some way to tell the Maven plugin to pass `${micronaut.core.version}` as
a literal string value.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
