### PR TITLE
Reduce the amount of classpath scanning during test runs.

### DIFF
--- a/src/test/java/org/openrewrite/java/micronaut/AddMicronautRetryDependencyIfNeededTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/AddMicronautRetryDependencyIfNeededTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.micronaut;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 
@@ -31,7 +32,11 @@ public class AddMicronautRetryDependencyIfNeededTest extends Micronaut4RewriteTe
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "jakarta.inject-api-2.*", "micronaut-retry-4.*"));
-        spec.recipeFromResource("/META-INF/rewrite/micronaut3-to-4.yml", "org.openrewrite.java.micronaut.AddMicronautRetryDependencyIfNeeded");
+        spec.recipes(Environment.builder()
+          .scanRuntimeClasspath("org.openrewrite.java.micronaut")
+          .build()
+          .activateRecipes( "org.openrewrite.java.micronaut.AddMicronautRetryDependencyIfNeeded"));
+
     }
 
     @Language("java")

--- a/src/test/java/org/openrewrite/java/micronaut/AddMicronautWebsocketDependencyIfNeededTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/AddMicronautWebsocketDependencyIfNeededTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.micronaut;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 
@@ -31,7 +32,10 @@ public class AddMicronautWebsocketDependencyIfNeededTest extends Micronaut4Rewri
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "micronaut-websocket-4.*"));
-        spec.recipeFromResource("/META-INF/rewrite/micronaut3-to-4.yml", "org.openrewrite.java.micronaut.AddMicronautWebsocketDependencyIfNeeded");
+        spec.recipes(Environment.builder()
+          .scanRuntimeClasspath("org.openrewrite.java.micronaut")
+          .build()
+          .activateRecipes( "org.openrewrite.java.micronaut.AddMicronautWebsocketDependencyIfNeeded"));
     }
 
     @Language("java")

--- a/src/test/java/org/openrewrite/java/micronaut/RemoveUnnecessaryDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/RemoveUnnecessaryDependenciesTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.micronaut;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.config.Environment;
 import org.openrewrite.test.RecipeSpec;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
@@ -27,7 +28,10 @@ public class RemoveUnnecessaryDependenciesTest extends Micronaut4RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipeFromResource("/META-INF/rewrite/micronaut3-to-4.yml", "org.openrewrite.java.micronaut.RemoveUnnecessaryDependencies");
+        spec.recipes(Environment.builder()
+          .scanRuntimeClasspath("org.openrewrite.java.micronaut")
+          .build()
+          .activateRecipes( "org.openrewrite.java.micronaut.RemoveUnnecessaryDependencies"));
     }
 
     @Test

--- a/src/test/java/org/openrewrite/java/micronaut/RemoveWithJansiLogbackConfigurationTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/RemoveWithJansiLogbackConfigurationTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.micronaut;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.config.Environment;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -27,7 +28,10 @@ public class RemoveWithJansiLogbackConfigurationTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipeFromResource("/META-INF/rewrite/micronaut3-to-4.yml", "org.openrewrite.java.micronaut.RemoveWithJansiLogbackConfiguration");
+        spec.recipes(Environment.builder()
+          .scanRuntimeClasspath("org.openrewrite.java.micronaut")
+          .build()
+          .activateRecipes( "org.openrewrite.java.micronaut.RemoveWithJansiLogbackConfiguration"));
     }
 
     @Test

--- a/src/test/java/org/openrewrite/java/micronaut/UpdateBuildPluginsTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpdateBuildPluginsTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.micronaut;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.config.Environment;
 import org.openrewrite.test.RecipeSpec;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
@@ -29,7 +30,10 @@ public class UpdateBuildPluginsTest extends Micronaut4RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipeFromResource("/META-INF/rewrite/micronaut3-to-4.yml", "org.openrewrite.java.micronaut.UpdateMicronautPlatformBom", "org.openrewrite.java.micronaut.UpdateBuildPlugins");
+        spec.recipes(Environment.builder()
+          .scanRuntimeClasspath("org.openrewrite.java.micronaut")
+          .build()
+          .activateRecipes( "org.openrewrite.java.micronaut.UpdateMicronautPlatformBom", "org.openrewrite.java.micronaut.UpdateBuildPlugins"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/micronaut/UpdateBuildToMicronaut4VersionTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpdateBuildToMicronaut4VersionTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.micronaut;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 
@@ -28,7 +29,10 @@ public class UpdateBuildToMicronaut4VersionTest extends Micronaut4RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "micronaut-context-4.*"));
-        spec.recipeFromResource("/META-INF/rewrite/micronaut3-to-4.yml", "org.openrewrite.java.micronaut.UpdateBuildToMicronaut4Version");
+        spec.recipes(Environment.builder()
+          .scanRuntimeClasspath("org.openrewrite.java.micronaut")
+          .build()
+          .activateRecipes( "org.openrewrite.java.micronaut.UpdateBuildToMicronaut4Version"));
     }
 
     @Test

--- a/src/test/java/org/openrewrite/java/micronaut/UpdateMicronautEmailTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpdateMicronautEmailTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.micronaut;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -29,7 +30,10 @@ public class UpdateMicronautEmailTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "micronaut-email-2.0.*", "jakarta.inject-api-2.*", "jakarta.mail-api-2.*", "javax.mail-api-1.*"));
-        spec.recipeFromResource("/META-INF/rewrite/micronaut3-to-4.yml", "org.openrewrite.java.micronaut.UpdateMicronautEmail");
+        spec.recipes(Environment.builder()
+          .scanRuntimeClasspath("org.openrewrite.java.micronaut")
+          .build()
+          .activateRecipes( "org.openrewrite.java.micronaut.UpdateMicronautEmail"));
     }
 
     @Language("java")

--- a/src/test/java/org/openrewrite/java/micronaut/UpdateMicronautSecurityTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpdateMicronautSecurityTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.micronaut;
 
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.config.Environment;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -29,7 +30,10 @@ public class UpdateMicronautSecurityTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipeFromResource("/META-INF/rewrite/micronaut3-to-4.yml", "org.openrewrite.java.micronaut.UpdateMicronautSecurity");
+        spec.recipes(Environment.builder()
+          .scanRuntimeClasspath("org.openrewrite.java.micronaut")
+          .build()
+          .activateRecipes( "org.openrewrite.java.micronaut.UpdateMicronautSecurity"));
     }
 
     @Language("properties")

--- a/src/test/java/org/openrewrite/java/micronaut/UpdateMicronautSessionTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpdateMicronautSessionTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.micronaut;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.config.Environment;
 import org.openrewrite.test.RecipeSpec;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
@@ -26,7 +27,10 @@ public class UpdateMicronautSessionTest extends Micronaut4RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipeFromResource("/META-INF/rewrite/micronaut3-to-4.yml", "org.openrewrite.java.micronaut.UpdateMicronautPlatformBom", "org.openrewrite.java.micronaut.UpdateMicronautSession");
+        spec.recipes(Environment.builder()
+          .scanRuntimeClasspath("org.openrewrite.java.micronaut")
+          .build()
+          .activateRecipes( "org.openrewrite.java.micronaut.UpdateMicronautPlatformBom", "org.openrewrite.java.micronaut.UpdateMicronautSession"));
     }
 
     @Test


### PR DESCRIPTION
## What's changed?
Updated all of the tests to use filtered classpath scanning to remedy the persistent heap space errors that were 
happening when running the full test suite locally.

This had a side-benefit of shortening the time taken to execute all tests by a full minute.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
