### PR TITLE
Add micronaut-inject exclusion to non-core annotation processors.

### DIFF
--- a/src/main/java/org/openrewrite/java/micronaut/ChangeAnnotationProcessorPath.java
+++ b/src/main/java/org/openrewrite/java/micronaut/ChangeAnnotationProcessorPath.java
@@ -95,11 +95,7 @@ public class ChangeAnnotationProcessorPath extends Recipe {
 
         return new MavenVisitor<ExecutionContext>() {
 
-            final DependencyMatcher depMatcher;
-
-            {
-                this.depMatcher = Objects.requireNonNull(DependencyMatcher.build(ChangeAnnotationProcessorPath.this.oldGroupId + ":" + ChangeAnnotationProcessorPath.this.oldArtifactId).getValue());
-            }
+            final DependencyMatcher depMatcher = Objects.requireNonNull(DependencyMatcher.build(ChangeAnnotationProcessorPath.this.oldGroupId + ":" + ChangeAnnotationProcessorPath.this.oldArtifactId).getValue());
 
             @Override
             public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {

--- a/src/main/java/org/openrewrite/java/micronaut/ChangeAnnotationProcessorPath.java
+++ b/src/main/java/org/openrewrite/java/micronaut/ChangeAnnotationProcessorPath.java
@@ -25,11 +25,13 @@ import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.maven.MavenVisitor;
+import org.openrewrite.semver.DependencyMatcher;
 import org.openrewrite.xml.AddOrUpdateChild;
 import org.openrewrite.xml.ChangeTagValueVisitor;
 import org.openrewrite.xml.tree.Xml;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -90,7 +92,14 @@ public class ChangeAnnotationProcessorPath extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
+
         return new MavenVisitor<ExecutionContext>() {
+
+            final DependencyMatcher depMatcher;
+
+            {
+                this.depMatcher = Objects.requireNonNull(DependencyMatcher.build(ChangeAnnotationProcessorPath.this.oldGroupId + ":" + ChangeAnnotationProcessorPath.this.oldArtifactId).getValue());
+            }
 
             @Override
             public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
@@ -151,8 +160,8 @@ public class ChangeAnnotationProcessorPath extends Recipe {
             }
 
             private boolean isPathMatch(Xml.Tag path) {
-                return oldGroupId.equals(path.getChildValue("groupId").orElse(null)) &&
-                        oldArtifactId.equals(path.getChildValue("artifactId").orElse(null));
+                return this.depMatcher.matches(path.getChildValue("groupId").orElse(""),
+                        path.getChildValue("artifactId").orElse(""));
             }
 
             private Xml.Tag changeChildTagValue(Xml.Tag tag, String childTagName, String newValue, ExecutionContext ctx) {

--- a/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
+++ b/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
@@ -393,3 +393,8 @@ recipeList:
       oldGroupId: io.micronaut
       oldArtifactId: micronaut-graal
       newVersion: micronaut.core.version
+  - org.openrewrite.java.micronaut.ChangeAnnotationProcessorPath:
+      oldGroupId: io.micronaut.*
+      oldArtifactId: micronaut-*
+      exclusions:
+        - io.micronaut:micronaut-inject

--- a/src/test/java/org/openrewrite/java/micronaut/UpdateMavenAnnotationProcessorsTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpdateMavenAnnotationProcessorsTest.java
@@ -195,7 +195,7 @@ public class UpdateMavenAnnotationProcessorsTest extends Micronaut4RewriteTest {
     }
 
     @Test
-    void updateCoreMavenAnnotationProcessorsAndDontModifyModuleProcessors() {
+    void updateCoreMavenAnnotationProcessorsAndAddExclusionToModuleProcessors() {
         rewriteRun(
           //language=xml
           pomXml("""
@@ -318,6 +318,12 @@ public class UpdateMavenAnnotationProcessorsTest extends Micronaut4RewriteTest {
                                         <groupId>io.micronaut.data</groupId>
                                         <artifactId>micronaut-data-processor</artifactId>
                                         <version>${micronaut.data.version}</version>
+                                        <exclusions>
+                                            <exclusion>
+                                                <groupId>io.micronaut</groupId>
+                                                <artifactId>micronaut-inject</artifactId>
+                                            </exclusion>
+                                        </exclusions>
                                     </path>
                                     <path>
                                         <groupId>io.micronaut</groupId>


### PR DESCRIPTION
## What's changed?
The `UpdateMavenAnnotationProcessors` recipe has been modified to add an exclusion for `micronaut-inject` to all
non-core Micronaut annotation processors (in other words, annotation processors with a `io.micronaut.*` Group Id).

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
