### PR TITLE
Switch from `JavaxAnnotationPackageToJakarta` to `JavaxAnnotationMigrationToJakartaAnnotation`

### DIFF
--- a/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
+++ b/src/main/resources/META-INF/rewrite/micronaut3-to-4.yml
@@ -121,7 +121,7 @@ name: org.openrewrite.java.micronaut.UpdateJakartaAnnotations
 displayName: Update jakarta annotations dependency
 description: This recipe will remove jakarta annotations dependency as it is a transitive dependency of micronaut-inject, and migrate from javax.annotation if needed.
 recipeList:
-  - org.openrewrite.java.migrate.jakarta.JavaxAnnotationPackageToJakarta
+  - org.openrewrite.java.migrate.jakarta.JavaxAnnotationMigrationToJakartaAnnotation
   - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: jakarta.annotation
       artifactId: jakarta.annotation-api


### PR DESCRIPTION
## What's changed?
Switch to consolidated recipe

## What's your motivation?
Recipes were consolidated in
- https://github.com/openrewrite/rewrite-migrate-java/pull/356