### PR TITLE
fixed type on J.ParameterizedType#clazz in SubclassesReturnedFromFactoriesNotInjectable.

### DIFF
--- a/src/main/java/org/openrewrite/java/micronaut/SubclassesReturnedFromFactoriesNotInjectable.java
+++ b/src/main/java/org/openrewrite/java/micronaut/SubclassesReturnedFromFactoriesNotInjectable.java
@@ -105,6 +105,9 @@ public class SubclassesReturnedFromFactoriesNotInjectable extends Recipe {
                     J.Identifier resolvedReturnType = new J.Identifier(UUID.randomUUID(), Space.EMPTY, Markers.EMPTY, emptyList(), returnedTypeFqn.getClassName(), returnedType, null);
                     if (returnedType instanceof JavaType.Parameterized && md.getReturnTypeExpression() instanceof J.ParameterizedType) {
                         J.ParameterizedType mdReturnTypeExpression = (J.ParameterizedType) md.getReturnTypeExpression();
+                        if (resolvedReturnType.getType() instanceof JavaType.Parameterized) {
+                            resolvedReturnType = resolvedReturnType.withType(((JavaType.Parameterized) resolvedReturnType.getType()).getType());
+                        }
                         mdReturnTypeExpression = mdReturnTypeExpression.withClazz(resolvedReturnType);
                         md = maybeAutoFormat(md, md.withReturnTypeExpression(mdReturnTypeExpression), md.getName(), executionContext, getCursor().getParent());
                     } else {


### PR DESCRIPTION
Changes:

- The `J.ParameterizedType#clazz` field will have a `JavaType$Class` type after the recipe makes changes.