### PR TITLE
`org.openrewrite.gradle.Assertions#withToolingModel` moved to `org.openrewrite.gradle.toolingapi.Assertions`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
 
     testImplementation("org.openrewrite:rewrite-test")
     testImplementation("org.openrewrite:rewrite-java-tck")
+    testImplementation("org.openrewrite.gradle.tooling:model:$rewriteVersion")
     testImplementation("org.assertj:assertj-core:latest.release")
     testRuntimeOnly(gradleApi())
 }

--- a/src/test/java/org/openrewrite/java/micronaut/AddMicronautRetryDependencyIfNeededTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/AddMicronautRetryDependencyIfNeededTest.java
@@ -23,7 +23,7 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
 

--- a/src/test/java/org/openrewrite/java/micronaut/AddMicronautWebsocketDependencyIfNeededTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/AddMicronautWebsocketDependencyIfNeededTest.java
@@ -23,7 +23,7 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
 

--- a/src/test/java/org/openrewrite/java/micronaut/AddSnakeYamlDependencyIfNeededTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/AddSnakeYamlDependencyIfNeededTest.java
@@ -22,7 +22,7 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
 import static org.openrewrite.properties.Assertions.properties;

--- a/src/test/java/org/openrewrite/java/micronaut/RemoveUnnecessaryDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/RemoveUnnecessaryDependenciesTest.java
@@ -20,7 +20,7 @@ import org.openrewrite.config.Environment;
 import org.openrewrite.test.RecipeSpec;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 

--- a/src/test/java/org/openrewrite/java/micronaut/UpdateBuildPluginsTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpdateBuildPluginsTest.java
@@ -21,7 +21,7 @@ import org.openrewrite.config.Environment;
 import org.openrewrite.test.RecipeSpec;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
 import static org.openrewrite.properties.Assertions.properties;

--- a/src/test/java/org/openrewrite/java/micronaut/UpdateJakartaAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpdateJakartaAnnotationsTest.java
@@ -23,7 +23,7 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
 

--- a/src/test/java/org/openrewrite/java/micronaut/UpdateMicronautValidationTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpdateMicronautValidationTest.java
@@ -23,7 +23,7 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
-import static org.openrewrite.gradle.Assertions.withToolingApi;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
 import static org.openrewrite.properties.Assertions.properties;


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.java.ChangeMethodTargetToStatic?organizationId=T3BlblJld3JpdGU%3D