### PR TITLE
Troubleshoot MergeYaml composite recipe failure

### DIFF
--- a/src/test/java/org/openrewrite/java/micronaut/UpdateMicronautSecurityTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpdateMicronautSecurityTest.java
@@ -38,100 +38,98 @@ class UpdateMicronautSecurityTest implements RewriteTest {
 
     @Language("properties")
     private final String initialSecurityProps = """
-            micronaut.security.token.jwt.generator.access-token.expiration=1d
-            micronaut.security.token.jwt.cookie.enabled=true
-            micronaut.security.token.jwt.cookie.cookie-max-age=1d
-            micronaut.security.token.jwt.cookie.cookie-path=foo
-            micronaut.security.token.jwt.cookie.cookie-domain=bar.com
-            micronaut.security.token.jwt.cookie.cookie-same-site=true
-            micronaut.security.token.jwt.bearer.enabled=true
-        """;
+      micronaut.security.token.jwt.generator.access-token.expiration=1d
+      micronaut.security.token.jwt.cookie.enabled=true
+      micronaut.security.token.jwt.cookie.cookie-max-age=1d
+      micronaut.security.token.jwt.cookie.cookie-path=foo
+      micronaut.security.token.jwt.cookie.cookie-domain=bar.com
+      micronaut.security.token.jwt.cookie.cookie-same-site=true
+      micronaut.security.token.jwt.bearer.enabled=true
+      """;
 
     @Language("properties")
     private final String expectedSecurityProps = """
-            micronaut.security.token.generator.access-token.expiration=1d
-            micronaut.security.token.cookie.enabled=true
-            micronaut.security.token.cookie.cookie-max-age=1d
-            micronaut.security.token.cookie.cookie-path=foo
-            micronaut.security.token.cookie.cookie-domain=bar.com
-            micronaut.security.token.cookie.cookie-same-site=true
-            micronaut.security.token.bearer.enabled=true
-        """;
+      micronaut.security.token.generator.access-token.expiration=1d
+      micronaut.security.token.cookie.enabled=true
+      micronaut.security.token.cookie.cookie-max-age=1d
+      micronaut.security.token.cookie.cookie-path=foo
+      micronaut.security.token.cookie.cookie-domain=bar.com
+      micronaut.security.token.cookie.cookie-same-site=true
+      micronaut.security.token.bearer.enabled=true
+      """;
 
     @Language("yml")
     private final String initialSecurityYaml = """
-            micronaut:
-                security:
-                    token:
-                        jwt:
-                            generator:
-                                access-token:
-                                    expiration: 1d
-                            cookie:
-                                enabled: true
-                                cookie-max-age: 1d
-                                cookie-path: foo
-                                cookie-domain: bar.com
-                                cookie-same-site: true
-                            bearer:
-                                enabled: true
-        """;
+      micronaut:
+        security:
+          token:
+            jwt:
+              generator:
+                access-token:
+                  expiration: 1d
+              cookie:
+                enabled: true
+                cookie-max-age: 1d
+                cookie-path: foo
+                cookie-domain: bar.com
+                cookie-same-site: true
+              bearer:
+                enabled: true
+      """;
 
     @Language("yml")
     private final String expectedSecurityYaml = """
-            micronaut:
-                security:
-                    token:
-                        generator:
-                            access-token:
-                                expiration: 1d
-                        cookie:
-                            enabled: true
-                            cookie-max-age: 1d
-                            cookie-path: foo
-                            cookie-domain: bar.com
-                            cookie-same-site: true
-                        bearer:
-                            enabled: true
-        """;
+      micronaut:
+        security:
+          token:
+            generator:
+              access-token:
+                expiration: 1d
+            cookie:
+              enabled: true
+              cookie-max-age: 1d
+              cookie-path: foo
+              cookie-domain: bar.com
+              cookie-same-site: true
+            bearer:
+              enabled: true
+      """;
 
     @Language("yml")
     private final String initialSecurityYamlPartial = """
-            micronaut:
-                security:
-                    token:
-                        jwt:
-                            generator:
-                                access-token:
-                                    expiration: 1d
-                            cookie:
-                                enabled: false
-                            bearer:
-                                enabled: true
-        """;
+      micronaut:
+        security:
+          token:
+            jwt:
+              generator:
+                access-token:
+                  expiration: 1d
+              cookie:
+                enabled: false
+              bearer:
+                enabled: true
+      """;
 
     @Language("yml")
     private final String expectedSecurityYamlPartial = """
-            micronaut:
-                security:
-                    token:
-                        generator:
-                            access-token:
-                                expiration: 1d
-                        cookie:
-                            enabled: false
-                        bearer:
-                            enabled: true
-        """;
+      micronaut:
+        security:
+          token:
+            generator:
+              access-token:
+                expiration: 1d
+            cookie:
+              enabled: false
+            bearer:
+              enabled: true
+      """;
 
     @Language("yml")
     private final String noJwtConfig = """
-            micronaut:
-                application:
-                    name: foo
-        """;
-
-
+      micronaut:
+        application:
+          name: foo
+      """;
 
     @Test
     void updatePropertyConfig() {


### PR DESCRIPTION
There's a new failure on main; this PR aims to troubleshoot / fix that failure, starting with a reformat of the test inputs from four to two spaces.

```diff
org.opentest4j.AssertionFailedError: [Unexpected result in "project/src/main/resources/application.yml":	
diff --git a/project/src/main/resources/application.yml b/project/src/main/resources/application.yml	
index d189fce..d535bb0 100644	
--- a/project/src/main/resources/application.yml	
+++ b/project/src/main/resources/application.yml	
@@ -3,12 +3,12 @@ 	
         token:	
             generator:	
                 access-token:	
-                    expiration: 1d	
+                    expiration:1d	
             cookie:	
-                enabled: true	
-                cookie-max-age: 1d	
-                cookie-path: foo	
-                cookie-domain: bar.com	
-                cookie-same-site: true	
+                enabled:true	
+                cookie-max-age:1d	
+                cookie-path:foo	
+                cookie-domain:bar.com	
+                cookie-same-site:true	
             bearer:	
-                enabled: true	
\ No newline at end of file	
+                enabled:true	
\ No newline at end of file	
```

expected:
```yaml 
  micronaut:	
      security:	
          token:	
              generator:	
                  access-token:	
                      expiration: 1d	
              cookie:	
                  enabled: true	
                  cookie-max-age: 1d	
                  cookie-path: foo	
                  cookie-domain: bar.com	
                  cookie-same-site: true	
              bearer:	
                  enabled: true
```	
 but was:
```yaml
  micronaut:	
      security:	
          token:	
              generator:	
                  access-token:	
                      expiration:1d	
              cookie:	
                  enabled:true	
                  cookie-max-age:1d	
                  cookie-path:foo	
                  cookie-domain:bar.com	
                  cookie-same-site:true	
              bearer:	
                  enabled:true"	
```

Notice the lack of spacing between the key and value.

The effective recipe is here:
https://github.com/openrewrite/rewrite-micronaut/blob/d3470d59504b43721e7e43ba0e406b9b29635c9e/src/main/java/org/openrewrite/java/micronaut/UpdateSecurityYamlIfNeeded.java#L62-L75

Any quick insight into these new failures after the [recent changes to MergeYaml](https://github.com/openrewrite/rewrite/commit/159f27c215be4efe82d5b6ddf7c6ccf27d0d3e6e) @sambsnyd ?