### PR TITLE
fix: update migration recipe path for Jakarta compatibility

### DIFF
--- a/src/main/resources/META-INF/rewrite/micronaut2-to-3.yml
+++ b/src/main/resources/META-INF/rewrite/micronaut2-to-3.yml
@@ -19,7 +19,7 @@ name: org.openrewrite.java.micronaut.Micronaut2to3Migration
 displayName: Migrate from Micronaut 2.x to 3.x
 description: This recipe will apply changes required for migrating from Micronaut 2 to Micronaut 3.
 recipeList:
-  - org.openrewrite.java.migrate.JavaxMigrationToJakarta
+  - org.openrewrite.java.migrate.jakarta.JavaxMigrationToJakarta
   - org.openrewrite.java.micronaut.BeanPropertyCapitalizationStrategy
   - org.openrewrite.java.micronaut.CopyNonInheritedAnnotations
   - org.openrewrite.java.micronaut.SubclassesReturnedFromFactoriesNotInjectable


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Fix for non-existing Jakarta recipe.

## What's your motivation?
Just a simple fix. Tested also with my project.

## Anything in particular you'd like reviewers to focus on?
Error log:

````
> Task :rewriteRun
Validating active recipes
Recipe validation error in initialization: DeclarativeRecipe must not contain uninitialized recipes. Be sure to call .initialize() on DeclarativeRecipe.
Recipe validation error in org.openrewrite.java.micronaut.UpgradeMicronautGradlePropertiesVersion: Recipe class org.openrewrite.java.micronaut.UpgradeMicronautGradlePropertiesVersion cannot be found
Recipe validation error in org.openrewrite.java.micronaut.UpgradeMicronautMavenPropertyVersion: Recipe class org.openrewrite.java.micronaut.UpgradeMicronautMavenPropertyVersion cannot be found
Recipe validation error in org.openrewrite.java.micronaut.Micronaut2to3Migration.recipeList[0] (in file:/Users/20011125/git/rewrite-micronaut/src/main/resources/META-INF/rewrite/micronaut2-to-3.yml): recipe 'org.openrewrite.java.migrate.JavaxMigrationToJakarta' does not exist.
Recipe validation error in org.openrewrite.java.micronaut.Micronaut2to3Migration.recipeList[1] (in file:/Users/20011125/git/rewrite-micronaut/src/main/resources/META-INF/rewrite/micronaut2-to-3.yml): recipe 'org.openrewrite.java.micronaut.BeanPropertyCapitalizationStrategy' does not exist.
Recipe validation error in org.openrewrite.java.micronaut.Micronaut2to3Migration.recipeList[2] (in file:/Users/20011125/git/rewrite-micronaut/src/main/resources/META-INF/rewrite/micronaut2-to-3.yml): recipe 'org.openrewrite.java.micronaut.CopyNonInheritedAnnotations' does not exist.
Recipe validation error in org.openrewrite.java.micronaut.Micronaut2to3Migration.recipeList[3] (in file:/Users/20011125/git/rewrite-micronaut/src/main/resources/META-INF/rewrite/micronaut2-to-3.yml): recipe 'org.openrewrite.java.micronaut.SubclassesReturnedFromFactoriesNotInjectable' does not exist.
Recipe validation error in org.openrewrite.java.micronaut.Micronaut2to3Migration.recipeList[4] (in file:/Users/20011125/git/rewrite-micronaut/src/main/resources/META-INF/rewrite/micronaut2-to-3.yml): recipe 'org.openrewrite.java.micronaut.OncePerRequestHttpServerFilterToHttpServerFilter' does not exist.
Recipe validation error in org.openrewrite.java.micronaut.Micronaut2to3Migration.recipeList[5] (in file:/Users/20011125/git/rewrite-micronaut/src/main/resources/META-INF/rewrite/micronaut2-to-3.yml): recipe 'org.openrewrite.java.micronaut.ProviderImplementationsToMicronautFactories' does not exist.
Recipe validation error in org.openrewrite.java.micronaut.Micronaut2to3Migration.recipeList[6] (in file:/Users/20011125/git/rewrite-micronaut/src/main/resources/META-INF/rewrite/micronaut2-to-3.yml): recipe 'org.openrewrite.java.micronaut.TypeRequiresIntrospection' does not exist.
Recipe validation error in org.openrewrite.java.micronaut.Micronaut2to3Migration.recipeList[7] (in file:/Users/20011125/git/rewrite-micronaut/src/main/resources/META-INF/rewrite/micronaut2-to-3.yml): recipe 'org.openrewrite.java.micronaut.FixDeprecatedExceptionHandlerConstructors' does not exist.
Recipe validation errors detected as part of one or more activeRecipe(s). Execution will continue regardless.
Scanning sources in project :
````

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
Custom recipe.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
