### PR TITLE
Replace MergeYaml with CopyValue createNewKeys to fix CI

### DIFF
--- a/src/main/java/org/openrewrite/java/micronaut/UpdateSecurityYamlIfNeeded.java
+++ b/src/main/java/org/openrewrite/java/micronaut/UpdateSecurityYamlIfNeeded.java
@@ -19,7 +19,6 @@ import lombok.Getter;
 import org.openrewrite.Recipe;
 import org.openrewrite.yaml.CopyValue;
 import org.openrewrite.yaml.DeleteKey;
-import org.openrewrite.yaml.MergeYaml;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,19 +30,6 @@ public class UpdateSecurityYamlIfNeeded extends Recipe {
     @Getter
     private final List<Recipe> recipeList = new ArrayList<>();
 
-    private final String newYamlKeysSnippet =
-            "generator:\n" +
-            "  access-token:\n" +
-            "    expiration:\n" +
-            "cookie:\n" +
-            "  enabled:\n" +
-            "  cookie-max-age:\n" +
-            "  cookie-path:\n" +
-            "  cookie-domain:\n" +
-            "  cookie-same-site:\n" +
-            "bearer:\n" +
-            "  enabled:";
-
     private static final String TOKEN_PATH = "$.micronaut.security.token";
 
     @Getter
@@ -53,14 +39,13 @@ public class UpdateSecurityYamlIfNeeded extends Recipe {
     final String description = "This recipe will update relocated security config keys in Micronaut configuration yaml files.";
 
     public UpdateSecurityYamlIfNeeded() {
-        this.recipeList.add(new MergeYaml("$.micronaut.security.token", newYamlKeysSnippet, Boolean.TRUE, null, FILE_MATCHER, null, null, null));
-        this.recipeList.add(new CopyValue(TOKEN_PATH + ".jwt.generator.access-token.expiration", FILE_MATCHER, TOKEN_PATH + ".generator.access-token.expiration", FILE_MATCHER));
-        this.recipeList.add(new CopyValue(TOKEN_PATH + ".jwt.cookie.enabled", FILE_MATCHER, TOKEN_PATH + ".cookie.enabled", FILE_MATCHER));
-        this.recipeList.add(new CopyValue(TOKEN_PATH + ".jwt.cookie.cookie-max-age", FILE_MATCHER, TOKEN_PATH + ".cookie.cookie-max-age", FILE_MATCHER));
-        this.recipeList.add(new CopyValue(TOKEN_PATH + ".jwt.cookie.cookie-path", FILE_MATCHER, TOKEN_PATH + ".cookie.cookie-path", FILE_MATCHER));
-        this.recipeList.add(new CopyValue(TOKEN_PATH + ".jwt.cookie.cookie-domain", FILE_MATCHER, TOKEN_PATH + ".cookie.cookie-domain", FILE_MATCHER));
-        this.recipeList.add(new CopyValue(TOKEN_PATH + ".jwt.cookie.cookie-same-site", FILE_MATCHER, TOKEN_PATH + ".cookie.cookie-same-site", FILE_MATCHER));
-        this.recipeList.add(new CopyValue(TOKEN_PATH + ".jwt.bearer.enabled", FILE_MATCHER, TOKEN_PATH + ".bearer.enabled", FILE_MATCHER));
+        this.recipeList.add(new CopyValue(TOKEN_PATH + ".jwt.generator.access-token.expiration", FILE_MATCHER, TOKEN_PATH + ".generator.access-token.expiration", FILE_MATCHER, Boolean.TRUE));
+        this.recipeList.add(new CopyValue(TOKEN_PATH + ".jwt.cookie.enabled", FILE_MATCHER, TOKEN_PATH + ".cookie.enabled", FILE_MATCHER, Boolean.TRUE));
+        this.recipeList.add(new CopyValue(TOKEN_PATH + ".jwt.cookie.cookie-max-age", FILE_MATCHER, TOKEN_PATH + ".cookie.cookie-max-age", FILE_MATCHER, Boolean.TRUE));
+        this.recipeList.add(new CopyValue(TOKEN_PATH + ".jwt.cookie.cookie-path", FILE_MATCHER, TOKEN_PATH + ".cookie.cookie-path", FILE_MATCHER, Boolean.TRUE));
+        this.recipeList.add(new CopyValue(TOKEN_PATH + ".jwt.cookie.cookie-domain", FILE_MATCHER, TOKEN_PATH + ".cookie.cookie-domain", FILE_MATCHER, Boolean.TRUE));
+        this.recipeList.add(new CopyValue(TOKEN_PATH + ".jwt.cookie.cookie-same-site", FILE_MATCHER, TOKEN_PATH + ".cookie.cookie-same-site", FILE_MATCHER, Boolean.TRUE));
+        this.recipeList.add(new CopyValue(TOKEN_PATH + ".jwt.bearer.enabled", FILE_MATCHER, TOKEN_PATH + ".bearer.enabled", FILE_MATCHER, Boolean.TRUE));
         this.recipeList.add(new DeleteKey(TOKEN_PATH + ".jwt.generator", FILE_MATCHER));
         this.recipeList.add(new DeleteKey(TOKEN_PATH + ".jwt.cookie", FILE_MATCHER));
         this.recipeList.add(new DeleteKey(TOKEN_PATH + ".jwt.bearer", FILE_MATCHER));

--- a/src/main/java/org/openrewrite/java/micronaut/UpdateSecurityYamlIfNeeded.java
+++ b/src/main/java/org/openrewrite/java/micronaut/UpdateSecurityYamlIfNeeded.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.micronaut;
 
 import lombok.Getter;
 import org.openrewrite.*;
+import org.openrewrite.yaml.JsonPathMatcher;
 import org.openrewrite.yaml.ShiftFormatLeftVisitor;
 import org.openrewrite.yaml.YamlIsoVisitor;
 import org.openrewrite.yaml.tree.Yaml;
@@ -36,17 +37,16 @@ public class UpdateSecurityYamlIfNeeded extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
+        JsonPathMatcher jwtMatcher = new JsonPathMatcher("$.micronaut.security.token.jwt");
         return Preconditions.check(new FindSourceFiles(FILE_MATCHER).getVisitor(),
                 new YamlIsoVisitor<ExecutionContext>() {
                     @Override
                     public Yaml.Mapping visitMapping(Yaml.Mapping mapping, ExecutionContext ctx) {
                         Yaml.Mapping m = super.visitMapping(mapping, ctx);
-                        if (!isTokenMapping()) {
-                            return m;
-                        }
                         Yaml.Mapping.Entry jwtEntry = null;
                         for (Yaml.Mapping.Entry entry : m.getEntries()) {
-                            if ("jwt".equals(entry.getKey().getValue()) && entry.getValue() instanceof Yaml.Mapping) {
+                            if (entry.getValue() instanceof Yaml.Mapping &&
+                                    jwtMatcher.matches(new Cursor(getCursor(), entry))) {
                                 jwtEntry = entry;
                                 break;
                             }
@@ -81,25 +81,6 @@ public class UpdateSecurityYamlIfNeeded extends Recipe {
                     private int indentOf(String prefix) {
                         int lastNewline = prefix.lastIndexOf('\n');
                         return lastNewline >= 0 ? prefix.length() - lastNewline - 1 : prefix.length();
-                    }
-
-                    private boolean isTokenMapping() {
-                        String[] expectedKeys = {"token", "security", "micronaut"};
-                        int keyIndex = 0;
-                        Cursor c = getCursor();
-                        while (c != null && keyIndex < expectedKeys.length) {
-                            Object value = c.getValue();
-                            if (value instanceof Yaml.Mapping.Entry) {
-                                String key = ((Yaml.Mapping.Entry) value).getKey().getValue();
-                                if (key.equals(expectedKeys[keyIndex])) {
-                                    keyIndex++;
-                                } else {
-                                    return false;
-                                }
-                            }
-                            c = c.getParent();
-                        }
-                        return keyIndex == expectedKeys.length;
                     }
                 });
     }

--- a/src/main/java/org/openrewrite/java/micronaut/UpdateSecurityYamlIfNeeded.java
+++ b/src/main/java/org/openrewrite/java/micronaut/UpdateSecurityYamlIfNeeded.java
@@ -22,8 +22,10 @@ import org.openrewrite.yaml.ShiftFormatLeftVisitor;
 import org.openrewrite.yaml.YamlIsoVisitor;
 import org.openrewrite.yaml.tree.Yaml;
 
-import java.util.ArrayList;
+import org.openrewrite.internal.ListUtils;
+
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class UpdateSecurityYamlIfNeeded extends Recipe {
 
@@ -61,21 +63,19 @@ public class UpdateSecurityYamlIfNeeded extends Recipe {
                                 indentOf(jwtMapping.getEntries().get(0).getPrefix());
                         int shift = childIndent - jwtIndent;
 
-                        List<Yaml.Mapping.Entry> newEntries = new ArrayList<>();
-                        for (Yaml.Mapping.Entry entry : m.getEntries()) {
-                            if (entry.getKey().getValue().equals(jwtEntry.getKey().getValue())) {
-                                for (Yaml.Mapping.Entry child : jwtMapping.getEntries()) {
-                                    Yaml.Mapping.Entry promoted = child.withPrefix(jwtEntry.getPrefix());
-                                    if (shift > 0 && promoted.getValue() instanceof Yaml.Mapping) {
-                                        doAfterVisit(new ShiftFormatLeftVisitor<>(promoted.getValue(), shift));
+                        Yaml.Mapping.Entry finalJwtEntry = jwtEntry;
+                        int finalShift = shift;
+                        List<Yaml.Mapping.Entry> promoted = jwtMapping.getEntries().stream()
+                                .map(child -> {
+                                    Yaml.Mapping.Entry p = child.withPrefix(finalJwtEntry.getPrefix());
+                                    if (finalShift > 0 && p.getValue() instanceof Yaml.Mapping) {
+                                        doAfterVisit(new ShiftFormatLeftVisitor<>(p.getValue(), finalShift));
                                     }
-                                    newEntries.add(promoted);
-                                }
-                            } else {
-                                newEntries.add(entry);
-                            }
-                        }
-                        return m.withEntries(newEntries);
+                                    return p;
+                                })
+                                .collect(Collectors.toList());
+                        return m.withEntries(ListUtils.flatMap(m.getEntries(), entry ->
+                                entry.getKey().getValue().equals(finalJwtEntry.getKey().getValue()) ? promoted : entry));
                     }
 
                     private int indentOf(String prefix) {

--- a/src/main/java/org/openrewrite/java/micronaut/UpdateSecurityYamlIfNeeded.java
+++ b/src/main/java/org/openrewrite/java/micronaut/UpdateSecurityYamlIfNeeded.java
@@ -16,9 +16,10 @@
 package org.openrewrite.java.micronaut;
 
 import lombok.Getter;
-import org.openrewrite.Recipe;
-import org.openrewrite.yaml.CopyValue;
-import org.openrewrite.yaml.DeleteKey;
+import org.openrewrite.*;
+import org.openrewrite.yaml.ShiftFormatLeftVisitor;
+import org.openrewrite.yaml.YamlIsoVisitor;
+import org.openrewrite.yaml.tree.Yaml;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,27 +29,78 @@ public class UpdateSecurityYamlIfNeeded extends Recipe {
     private static final String FILE_MATCHER = "**/{application,application-*,bootstrap,bootstrap-*}.{yml,yaml}";
 
     @Getter
-    private final List<Recipe> recipeList = new ArrayList<>();
-
-    private static final String TOKEN_PATH = "$.micronaut.security.token";
-
-    @Getter
     final String displayName = "Update relocated Micronaut Security config yaml keys";
 
     @Getter
     final String description = "This recipe will update relocated security config keys in Micronaut configuration yaml files.";
 
-    public UpdateSecurityYamlIfNeeded() {
-        this.recipeList.add(new CopyValue(TOKEN_PATH + ".jwt.generator.access-token.expiration", FILE_MATCHER, TOKEN_PATH + ".generator.access-token.expiration", FILE_MATCHER, Boolean.TRUE));
-        this.recipeList.add(new CopyValue(TOKEN_PATH + ".jwt.cookie.enabled", FILE_MATCHER, TOKEN_PATH + ".cookie.enabled", FILE_MATCHER, Boolean.TRUE));
-        this.recipeList.add(new CopyValue(TOKEN_PATH + ".jwt.cookie.cookie-max-age", FILE_MATCHER, TOKEN_PATH + ".cookie.cookie-max-age", FILE_MATCHER, Boolean.TRUE));
-        this.recipeList.add(new CopyValue(TOKEN_PATH + ".jwt.cookie.cookie-path", FILE_MATCHER, TOKEN_PATH + ".cookie.cookie-path", FILE_MATCHER, Boolean.TRUE));
-        this.recipeList.add(new CopyValue(TOKEN_PATH + ".jwt.cookie.cookie-domain", FILE_MATCHER, TOKEN_PATH + ".cookie.cookie-domain", FILE_MATCHER, Boolean.TRUE));
-        this.recipeList.add(new CopyValue(TOKEN_PATH + ".jwt.cookie.cookie-same-site", FILE_MATCHER, TOKEN_PATH + ".cookie.cookie-same-site", FILE_MATCHER, Boolean.TRUE));
-        this.recipeList.add(new CopyValue(TOKEN_PATH + ".jwt.bearer.enabled", FILE_MATCHER, TOKEN_PATH + ".bearer.enabled", FILE_MATCHER, Boolean.TRUE));
-        this.recipeList.add(new DeleteKey(TOKEN_PATH + ".jwt.generator", FILE_MATCHER));
-        this.recipeList.add(new DeleteKey(TOKEN_PATH + ".jwt.cookie", FILE_MATCHER));
-        this.recipeList.add(new DeleteKey(TOKEN_PATH + ".jwt.bearer", FILE_MATCHER));
-        this.recipeList.add(new RemoveUnusedInConfigFiles());
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new FindSourceFiles(FILE_MATCHER).getVisitor(),
+                new YamlIsoVisitor<ExecutionContext>() {
+                    @Override
+                    public Yaml.Mapping visitMapping(Yaml.Mapping mapping, ExecutionContext ctx) {
+                        Yaml.Mapping m = super.visitMapping(mapping, ctx);
+                        if (!isTokenMapping()) {
+                            return m;
+                        }
+                        Yaml.Mapping.Entry jwtEntry = null;
+                        for (Yaml.Mapping.Entry entry : m.getEntries()) {
+                            if ("jwt".equals(entry.getKey().getValue()) && entry.getValue() instanceof Yaml.Mapping) {
+                                jwtEntry = entry;
+                                break;
+                            }
+                        }
+                        if (jwtEntry == null) {
+                            return m;
+                        }
+                        Yaml.Mapping jwtMapping = (Yaml.Mapping) jwtEntry.getValue();
+                        // Calculate indent shift: difference between jwt child indent and jwt indent
+                        int jwtIndent = indentOf(jwtEntry.getPrefix());
+                        int childIndent = jwtMapping.getEntries().isEmpty() ? jwtIndent :
+                                indentOf(jwtMapping.getEntries().get(0).getPrefix());
+                        int shift = childIndent - jwtIndent;
+
+                        List<Yaml.Mapping.Entry> newEntries = new ArrayList<>();
+                        for (Yaml.Mapping.Entry entry : m.getEntries()) {
+                            if (entry.getKey().getValue().equals(jwtEntry.getKey().getValue())) {
+                                for (Yaml.Mapping.Entry child : jwtMapping.getEntries()) {
+                                    Yaml.Mapping.Entry promoted = child.withPrefix(jwtEntry.getPrefix());
+                                    if (shift > 0 && promoted.getValue() instanceof Yaml.Mapping) {
+                                        doAfterVisit(new ShiftFormatLeftVisitor<>(promoted.getValue(), shift));
+                                    }
+                                    newEntries.add(promoted);
+                                }
+                            } else {
+                                newEntries.add(entry);
+                            }
+                        }
+                        return m.withEntries(newEntries);
+                    }
+
+                    private int indentOf(String prefix) {
+                        int lastNewline = prefix.lastIndexOf('\n');
+                        return lastNewline >= 0 ? prefix.length() - lastNewline - 1 : prefix.length();
+                    }
+
+                    private boolean isTokenMapping() {
+                        String[] expectedKeys = {"token", "security", "micronaut"};
+                        int keyIndex = 0;
+                        Cursor c = getCursor();
+                        while (c != null && keyIndex < expectedKeys.length) {
+                            Object value = c.getValue();
+                            if (value instanceof Yaml.Mapping.Entry) {
+                                String key = ((Yaml.Mapping.Entry) value).getKey().getValue();
+                                if (key.equals(expectedKeys[keyIndex])) {
+                                    keyIndex++;
+                                } else {
+                                    return false;
+                                }
+                            }
+                            c = c.getParent();
+                        }
+                        return keyIndex == expectedKeys.length;
+                    }
+                });
     }
 }

--- a/src/test/java/org/openrewrite/java/micronaut/UpdateMicronautSecurityTest.java
+++ b/src/test/java/org/openrewrite/java/micronaut/UpdateMicronautSecurityTest.java
@@ -143,16 +143,12 @@ class UpdateMicronautSecurityTest implements RewriteTest {
 
     @Test
     void updatePartialYamlConfig() {
-        rewriteRun(
-          spec -> spec.expectedCyclesThatMakeChanges(2),
-          mavenProject("project", srcMainResources(yaml(initialSecurityYamlPartial, expectedSecurityYamlPartial, s -> s.path("application.yml")))));
+        rewriteRun(mavenProject("project", srcMainResources(yaml(initialSecurityYamlPartial, expectedSecurityYamlPartial, s -> s.path("application.yml")))));
     }
 
     @Test
     void noJwtConfig() {
-        rewriteRun(
-          spec -> spec.expectedCyclesThatMakeChanges(2),
-          mavenProject("project", srcMainResources(yaml(noJwtConfig, noJwtConfig, s -> s.path("application.yml")))));
+        rewriteRun(mavenProject("project", srcMainResources(yaml(noJwtConfig, s -> s.path("application.yml")))));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `MergeYaml` from `rewrite-yaml` 8.77.0-SNAPSHOT regressed with an `AssertionError` in `visitNonNull`, breaking the scheduled CI on main
- Replaced `MergeYaml` skeleton creation with `CopyValue(createNewKeys=true)`, which creates destination keys directly during the copy operation
- Removed the now-unnecessary `newYamlKeysSnippet` field and `MergeYaml` import
- Updated test expectations: `updatePartialYamlConfig` no longer needs 2 cycles, and `noJwtConfig` correctly expects no changes when there's no `jwt` config

## Test plan
- [x] `UpdateMicronautSecurityTest` — all 6 tests pass
- [x] Full test suite passes
- [x] `gradle check` passes (including recipe CSV validation)